### PR TITLE
Add anchor links

### DIFF
--- a/Encodings.md
+++ b/Encodings.md
@@ -107,7 +107,7 @@ bit value: 00000101 00111001 01110111
 bit label: ABCDEFGH IJKLMNOP QRSTUVWX
 ```
 
-### Delta Encoding (DELTA_BINARY_PACKED = 5)
+### <a name="DELTAENC"></a>Delta Encoding (DELTA_BINARY_PACKED = 5)
 Supported Types: INT32, INT64
 
 This encoding is adapted from the Binary packing described in ["Decoding billions of integers per second through vectorization"](http://arxiv.org/pdf/1209.2137v5.pdf) by D. Lemire and L. Boytsov
@@ -182,8 +182,8 @@ The encoded data is
 0 (minimum delta), 2 (bitwidth), 000000111111b (0,0,0,3,3,3 packed on 2 bits)
 
 #### Characteristics
-This encoding is similar to the RLE encoding. However the RLE encoding (described here) is specifically used when the range of ints is small over the entire page, as is true of repetition and definition levels. It uses a single bit width for the whole page.
-The binary packing algorithm described above stores a bit width per mini block and is less sensitive to variations in the size of encoded integers. It is also somewhat doing RLE encoding as a block containing all the same values will be bit packed to a zero bit width thus being only a header.
+This encoding is similar to the [RLE/bit-packing](#RLE) encoding. However the [RLE/bit-packing](#RLE) encoding is specifically used when the range of ints is small over the entire page, as is true of repetition and definition levels. It uses a single bit width for the whole page.
+The delta encoding algorithm described above stores a bit width per mini block and is less sensitive to variations in the size of encoded integers. It is also somewhat doing RLE encoding as a block containing all the same values will be bit packed to a zero bit width thus being only a header.
 
 ### Delta-length byte array: (DELTA_LENGTH_BYTE_ARRAY = 6)
 


### PR DESCRIPTION
I'm starting work on a Haskell implementation of the Parquet format and wanted to get up to speed on the various encodings used.

I find that the current Encodings.md document is quite confusing.

This is a first pass at some clean-up.

There were multiple references in the text that made no sense, as they were references to sections which appear to have been re-ordered in the document.

I've rewritten those references as anchor links within the document to avoid future issues.
