### PR TITLE
PARQUET-119: add data_encodings to ColumnMetaData to enable dictionary based predicate push down

### DIFF
--- a/src/thrift/parquet.thrift
+++ b/src/thrift/parquet.thrift
@@ -430,7 +430,7 @@ struct SortingColumn {
 }
 
 /**
- * statistics of a give page type and encoding
+ * statistics of a given page type and encoding
  */
 struct PageEncodingStats {
 


### PR DESCRIPTION
To implement predicate push down based on dictionary we need to know if fallback happened.
If all data pages are dictionary encoded we can use the dictionary for predicate-push down.
If not we can not.

CC @nongli @rdblue @isnotinvain @tsdeng 
