### PR TITLE
PARQUET-412: Do not shade slf4j-api, update it's version to 1.7.16, r…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,18 +141,9 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.thrift:libthrift</include>
-                  <include>org.slf4j:slf4j-api</include>
-                  <include>org.slf4j:slf4j-nop</include>
                 </includes>
               </artifactSet>
               <filters>
-                <filter>
-                  <!-- Exclude SLF4J's meta files, covered by LICENSE and NOTICE -->
-                  <artifact>org.slf4j:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**/*</exclude>
-                  </excludes>
-                </filter>
                 <filter>
                   <!-- Sigh. The Thrift jar contains its source -->
                   <artifact>org.apache.thrift:libthrift</artifact>
@@ -167,10 +158,6 @@
                 <relocation>
                   <pattern>org.apache.thrift</pattern>
                   <shadedPattern>${shade.prefix}.org.apache.thrift</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.slf4j</pattern>
-                  <shadedPattern>${shade.prefix}.org.slf4j</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>
@@ -219,12 +206,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
-      <version>1.7.2</version>
+      <version>1.7.16</version>
     </dependency>
     <dependency>
       <groupId>org.apache.thrift</groupId>


### PR DESCRIPTION
…emove slf4j-nop
- Shading and using slf4j-nop cause dropping of thrift's log messages.
- Very unwanted side effect of SLF4J shading is also full disabling of application logging on first close of Parquet/Avro writer. It is probably due to StaticLoggerBinder singleton is present in the application twice with different full class names and due to their unpredictable conflicts. See PARQUET-408 for details.
- Rest of Parquet libraries have already switched to depend on slf4j-api explicitly so it doesn't make sense to shadow it here.
- slf4j-nop dependency is no longer needed, library should not depend on any concrete logger implementation.
- SLF4J 1.7.2 is four years old, update the version to the latest 1.7.16. There are no significant changes in the API (http://www.slf4j.org/news.html) so it is safe.
