### PR TITLE
PARQUET-655: Fixes LogicalTypes.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Annotations are stored as `ConvertedType` fields in the file metadata and are
 documented in
 [LogicalTypes.md][logical-types].
 
-[logical-types]: https://github.com/Parquet/parquet-format/blob/master/LogicalTypes.md
+[logical-types]: LogicalTypes.md
 
 ## Nested Encoding
 To encode nested columns, Parquet uses the Dremel encoding with definition and 


### PR DESCRIPTION
The current LogicalTypes.md link in README.md points to the the file in the old https://github.com/Parquet/parquet-format repository.

This PR replaces the stale link with a relative path so that it always points to the file in the right repository.