### PR TITLE
PARQUET-686: Add Order to store the order used for min/max stats.

### DIFF
--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -37,6 +37,8 @@ may require additional metadata fields, as well as rules for those fields.
 `UTF8` may only be used to annotate the binary primitive type and indicates
 that the byte array should be interpreted as a UTF-8 encoded character string.
 
+The sort order used for `UTF8` strings must be `UNSIGNED` byte-wise comparison.
+
 ## Numeric Types
 
 ### Signed Integers
@@ -55,6 +57,8 @@ allows.
 implied by the `int32` and `int64` primitive types if no other annotation is
 present and should be considered optional.
 
+The sort order used for signed integer types must be `SIGNED`.
+
 ### Unsigned Integers
 
 `UINT_8`, `UINT_16`, `UINT_32`, and `UINT_64` annotations can be used to
@@ -69,6 +73,8 @@ allows.
 
 `UINT_8`, `UINT_16`, and `UINT_32` must annotate an `int32` primitive type and
 `UINT_64` must annotate an `int64` primitive type.
+
+The sort order used for unsigned integer types must be `UNSIGNED`.
 
 ### DECIMAL
 
@@ -98,6 +104,15 @@ integer. A precision too large for the underlying type (see below) is an error.
 A `SchemaElement` with the `DECIMAL` `ConvertedType` must also have both
 `scale` and `precision` fields set, even if scale is 0 by default.
 
+The sort order used for `DECIMAL` values must be `SIGNED`. The order is
+must be equivalent to signed comparison of decimal values.
+
+If the column uses `int32` or `int64` physical types, then signed comparison of
+the integer values produces the correct ordering. If the physical type is
+fixed, then the correct ordering can be produced by flipping the
+most-significant bit in the first byte and then using unsigned byte-wise
+comparison.
+
 ## Date/Time Types
 
 ### DATE
@@ -106,11 +121,15 @@ A `SchemaElement` with the `DECIMAL` `ConvertedType` must also have both
 annotate an `int32` that stores the number of days from the Unix epoch, 1
 January 1970.
 
+The sort order used for `DATE` is `SIGNED`.
+
 ### TIME\_MILLIS
 
 `TIME_MILLIS` is used for a logical time type with millisecond precision,
 without a date. It must annotate an `int32` that stores the number of
 milliseconds after midnight.
+
+The sort order used for `TIME\_MILLIS` is `SIGNED`.
 
 ### TIME\_MICROS
 
@@ -118,17 +137,23 @@ milliseconds after midnight.
 without a date. It must annotate an `int64` that stores the number of
 microseconds after midnight.
 
+The sort order used for `TIME\_MICROS` is `SIGNED`.
+
 ### TIMESTAMP\_MILLIS
 
 `TIMESTAMP_MILLIS` is used for a combined logical date and time type, with
 millisecond precision. It must annotate an `int64` that stores the number of
 milliseconds from the Unix epoch, 00:00:00.000 on 1 January 1970, UTC.
 
+The sort order used for `TIMESTAMP\_MILLIS` is `SIGNED`.
+
 ### TIMESTAMP\_MICROS
 
 `TIMESTAMP_MICROS` is used for a combined logical date and time type with
 microsecond precision. It must annotate an `int64` that stores the number of
 microseconds from the Unix epoch, 00:00:00.000000 on 1 January 1970, UTC.
+
+The sort order used for `TIMESTAMP\_MICROS` is `SIGNED`.
 
 ### INTERVAL
 
@@ -143,6 +168,9 @@ Each component in this representation is independent of the others. For
 example, there is no requirement that a large number of days should be
 expressed as a mix of months and days because there is not a constant
 conversion from days to months.
+
+The sort order used for `INTERVAL` is `UNSIGNED`, produced by sorting by
+the value of months, then days, then milliseconds with unsigned comparison.
 
 ## Embedded Types
 

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -174,6 +174,8 @@ the value of months, then days, then milliseconds with unsigned comparison.
 
 ## Embedded Types
 
+Embedded types do not have type-specific orderings.
+
 ### JSON
 
 `JSON` is used for an embedded JSON document. It must annotate a `binary`

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -37,7 +37,7 @@ may require additional metadata fields, as well as rules for those fields.
 `UTF8` may only be used to annotate the binary primitive type and indicates
 that the byte array should be interpreted as a UTF-8 encoded character string.
 
-The sort order used for `UTF8` strings must be `UNSIGNED` byte-wise comparison.
+The sort order used for `UTF8` strings is `UNSIGNED` byte-wise comparison.
 
 ## Numeric Types
 
@@ -57,7 +57,7 @@ allows.
 implied by the `int32` and `int64` primitive types if no other annotation is
 present and should be considered optional.
 
-The sort order used for signed integer types must be `SIGNED`.
+The sort order used for signed integer types is `SIGNED`.
 
 ### Unsigned Integers
 
@@ -74,7 +74,7 @@ allows.
 `UINT_8`, `UINT_16`, and `UINT_32` must annotate an `int32` primitive type and
 `UINT_64` must annotate an `int64` primitive type.
 
-The sort order used for unsigned integer types must be `UNSIGNED`.
+The sort order used for unsigned integer types is `UNSIGNED`.
 
 ### DECIMAL
 
@@ -104,8 +104,8 @@ integer. A precision too large for the underlying type (see below) is an error.
 A `SchemaElement` with the `DECIMAL` `ConvertedType` must also have both
 `scale` and `precision` fields set, even if scale is 0 by default.
 
-The sort order used for `DECIMAL` values must be `SIGNED`. The order is
-must be equivalent to signed comparison of decimal values.
+The sort order used for `DECIMAL` values is `SIGNED`. The order is equivalent
+to signed comparison of decimal values.
 
 If the column uses `int32` or `int64` physical types, then signed comparison of
 the integer values produces the correct ordering. If the physical type is

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -547,6 +547,61 @@ struct RowGroup {
   4: optional list<SortingColumn> sorting_columns
 }
 
+/** Identifier for built-in sort order used to produce min and max values. */
+enum Order {
+  /**
+   * The signed ordering is the order produced by comparing single primitive
+   * values with a signed comparator, or the lexicographic ordering produced by
+   * comparing each byte of a binary or fixed using a signed comparator.
+   *
+   * (A signed comparator uses the most-significant bit as a sign bit; an
+   * unsigned comparator uses the most-significant bit as part of the value's
+   * magnitude. Note that unsigned comparison is not defined for floating
+   * point values.)
+   */
+  SIGNED = 0;
+
+  /**
+   * The unsigned ordering is produced by comparing single primitive values
+   * with an unsigned comparison, or the lexicographic ordering produced by
+   * comparing each byte of a binary or fixed using an unsigned comparator.
+   *
+   * (A signed comparator uses the most-significant bit as a sign bit; an
+   * unsigned comparator uses the most-significant bit as part of the value's
+   * magnitude. Note that unsigned comparison is not defined for floating
+   * point values.)
+   */
+  UNSIGNED = 1;
+
+  /**
+   * Identifiers for custom orderings, to be defined in the ColumnOrder struct.
+   */
+  //CUSTOM = 2;
+}
+
+/** Descriptor for the order used for min, max, and sorting values in a column
+ */
+struct ColumnOrder {
+  /** The order used for this column */
+  0: required Order order;
+
+  /** Whether the order used is ascending (true) or descending (false) */
+  1: required boolean is_ascending;
+
+  /**
+   * A string that identifies the order for this column. This field should be
+   * set if the order is any value other than SIGNED or UNSIGNED and is used to
+   * identify the actual order used for min, max, and soring values.
+   *
+   * This identifier should follow one of the following formats:
+   * * 'icu54:<locale-keyword>' - ICU 54 ordering for the ICU 54 locale keyword
+   *
+   * To define order formats other than those listed above, contact the Parquet
+   * list.
+   */
+  //2: optional string custom_order;
+}
+
 /**
  * Description for file metadata
  */
@@ -576,5 +631,8 @@ struct FileMetaData {
    * e.g. impala version 1.0 (build 6cf94d29b2b7115df4de2c06e2ab4326d721eb55)
    **/
   6: optional string created_by
+
+  /** Sort order used for each column in this file */
+  7: optional list<ColumnOrder> column_orders;
 }
 

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -599,24 +599,15 @@ enum Order {
   CUSTOM = 2;
 }
 
-/** Descriptor for the order used for min, max, and sorting values in a column
- */
-struct ColumnOrder {
-  /** The order used for this column */
-  1: required Order order;
+/** Empty structs to signal SIGNED or UNSIGNED sort orders */
+struct Signed {}
+struct Unsigned {}
 
-  /**
-   * A string that identifies the order for this column. This field should be
-   * set if the order is any value other than SIGNED or UNSIGNED and is used to
-   * identify the actual order used for min, max, and soring values.
-   *
-   * This identifier should follow one of the following formats:
-   * * 'icu54:<locale-keyword>' - ICU 54 ordering for the ICU 54 locale keyword
-   *
-   * To define order formats other than those listed above, contact the Parquet
-   * list.
-   */
-  2: optional string custom_order;
+/** Union containing the order used for min, max, and sorting values in a column
+ */
+union ColumnOrder {
+  1: Signed SIGNED;
+  2: Unsigned UNSIGNED;
 }
 
 /**
@@ -653,7 +644,7 @@ struct FileMetaData {
    * Sort order used for each column in this file.
    *
    * If this list is not present, then the order for each column is assumed to
-   * be SIGNED. In addition, min and max values for INTERVAL or DECIMAL stored
+   * be Signed. In addition, min and max values for INTERVAL or DECIMAL stored
    * as fixed or bytes should be ignored.
    */
   7: optional list<ColumnOrder> column_orders;

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -202,13 +202,33 @@ enum FieldRepetitionType {
  * All fields are optional.
  */
 struct Statistics {
-   /** min and max value of the column, encoded in PLAIN encoding */
+   /**
+    * DEPRECATED: min and max value of the column. Use min_value and max_value.
+    *
+    * Values are encoded using PLAIN encoding, except that variable-length byte
+    * arrays do not include a length prefix.
+    *
+    * These fields encode min and max values determined by SIGNED comparison
+    * only. New files should use the correct order for a column's logical type
+    * and store the values in the min_value and max_value fields.
+    *
+    * To support older readers, these may be set when the column order is
+    * SIGNED.
+    */
    1: optional binary max;
    2: optional binary min;
    /** count of null value in the column */
    3: optional i64 null_count;
    /** count of distinct values occurring */
    4: optional i64 distinct_count;
+   /**
+    * Min and max values for the column, determined by its ColumnOrder.
+    *
+    * Values are encoded using PLAIN encoding, except that variable-length byte
+    * arrays do not include a length prefix.
+    */
+   5: optional binary max_value;
+   6: optional binary min_value;
 }
 
 /**
@@ -576,7 +596,7 @@ enum Order {
   /**
    * Identifiers for custom orderings, to be defined in the ColumnOrder struct.
    */
-  //CUSTOM = 2;
+  CUSTOM = 2;
 }
 
 /** Descriptor for the order used for min, max, and sorting values in a column
@@ -596,7 +616,7 @@ struct ColumnOrder {
    * To define order formats other than those listed above, contact the Parquet
    * list.
    */
-  //2: optional string custom_order;
+  2: optional string custom_order;
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -583,10 +583,7 @@ enum Order {
  */
 struct ColumnOrder {
   /** The order used for this column */
-  0: required Order order;
-
-  /** Whether the order used is ascending (true) or descending (false) */
-  1: required boolean is_ascending;
+  1: required Order order;
 
   /**
    * A string that identifies the order for this column. This field should be

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -629,7 +629,13 @@ struct FileMetaData {
    **/
   6: optional string created_by
 
-  /** Sort order used for each column in this file */
+  /**
+   * Sort order used for each column in this file.
+   *
+   * If this list is not present, then the order for each column is assumed to
+   * be SIGNED. In addition, min and max values for INTERVAL or DECIMAL stored
+   * as fixed or bytes should be ignored.
+   */
   7: optional list<ColumnOrder> column_orders;
 }
 


### PR DESCRIPTION
This adds a new enum, `Order`, that will be set to the order used to produce the min and max values in all `Statistics` objects (at the page level). `Order` has 8 symbols: `SIGNED`, `UNSIGNED`, and 6 symbols for custom orderings. This also adds a `CustomOrder` struct that is used to map the custom order symbols to string descriptors, such as [order keywords used by ICU collating sequences](http://userguide.icu-project.org/collation/api#TOC-Instantiating-the-Predefined-Collators). `CustomOrder` mappings are stored in the file footer.