### PR TITLE
PARQUET-906: Add LogicalType annotation.

### DIFF
--- a/src/main/java/org/apache/parquet/format/LogicalTypes.java
+++ b/src/main/java/org/apache/parquet/format/LogicalTypes.java
@@ -49,7 +49,7 @@ public class LogicalTypes {
   public static final LogicalType UINT_16 = LogicalType.INTEGER(new IntType((byte) 16, false));
   public static final LogicalType UINT_32 = LogicalType.INTEGER(new IntType((byte) 32, false));
   public static final LogicalType UINT_64 = LogicalType.INTEGER(new IntType((byte) 64, false));
-  public static final LogicalType NULL = LogicalType.NULL(new NullType());
+  public static final LogicalType UNKNOWN = LogicalType.UNKNOWN(new NullType());
   public static final LogicalType JSON = LogicalType.JSON(new JsonType());
   public static final LogicalType BSON = LogicalType.BSON(new BsonType());
 }

--- a/src/main/java/org/apache/parquet/format/LogicalTypes.java
+++ b/src/main/java/org/apache/parquet/format/LogicalTypes.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.parquet.format;
 
 /**

--- a/src/main/java/org/apache/parquet/format/LogicalTypes.java
+++ b/src/main/java/org/apache/parquet/format/LogicalTypes.java
@@ -1,0 +1,41 @@
+package org.apache.parquet.format;
+
+/**
+ * Convenience instances of logical type classes.
+ */
+public class LogicalTypes {
+  public static class TimeUnits {
+    public static final TimeUnit MILLIS = TimeUnit.MILLIS(new MilliSeconds());
+    public static final TimeUnit MICROS = TimeUnit.MICROS(new MicroSeconds());
+  }
+
+  private static class EmbeddedFormats {
+    public static final EmbeddedFormat JSON = EmbeddedFormat.JSON(new JSON());
+    public static final EmbeddedFormat BSON = EmbeddedFormat.BSON(new BSON());
+  }
+
+  public static LogicalType DECIMAL(int scale, int precision) {
+    return LogicalType.DECIMAL(new DecimalType(scale, precision));
+  }
+
+  public static final LogicalType UTF8 = LogicalType.STRING(new StringType());
+  public static final LogicalType MAP  = LogicalType.MAP(new MapType());
+  public static final LogicalType LIST = LogicalType.LIST(new ListType());
+  public static final LogicalType ENUM = LogicalType.ENUM(new EnumType());
+  public static final LogicalType DATE = LogicalType.DATE(new DateType());
+  public static final LogicalType TIME_MILLIS = LogicalType.TIME(new TimeType(true, TimeUnits.MILLIS));
+  public static final LogicalType TIME_MICROS = LogicalType.TIME(new TimeType(true, TimeUnits.MICROS));
+  public static final LogicalType TIMESTAMP_MILLIS = LogicalType.TIMESTAMP(new TimestampType(true, TimeUnits.MILLIS));
+  public static final LogicalType TIMESTAMP_MICROS = LogicalType.TIMESTAMP(new TimestampType(true, TimeUnits.MICROS));
+  public static final LogicalType INT_8 = LogicalType.INTEGER(new IntType(8, true));
+  public static final LogicalType INT_16 = LogicalType.INTEGER(new IntType(16, true));
+  public static final LogicalType INT_32 = LogicalType.INTEGER(new IntType(32, true));
+  public static final LogicalType INT_64 = LogicalType.INTEGER(new IntType(64, true));
+  public static final LogicalType UINT_8 = LogicalType.INTEGER(new IntType(8, false));
+  public static final LogicalType UINT_16 = LogicalType.INTEGER(new IntType(16, false));
+  public static final LogicalType UINT_32 = LogicalType.INTEGER(new IntType(32, false));
+  public static final LogicalType UINT_64 = LogicalType.INTEGER(new IntType(64, false));
+  public static final LogicalType JSON = LogicalType.EMBEDDED(new EmbeddedType(EmbeddedFormats.JSON));
+  public static final LogicalType BSON = LogicalType.EMBEDDED(new EmbeddedType(EmbeddedFormats.BSON));
+  public static final LogicalType NULL = LogicalType.NULL(new NullType());
+}

--- a/src/main/java/org/apache/parquet/format/LogicalTypes.java
+++ b/src/main/java/org/apache/parquet/format/LogicalTypes.java
@@ -28,11 +28,6 @@ public class LogicalTypes {
     public static final TimeUnit MICROS = TimeUnit.MICROS(new MicroSeconds());
   }
 
-  private static class EmbeddedFormats {
-    public static final EmbeddedFormat JSON = EmbeddedFormat.JSON(new JSON());
-    public static final EmbeddedFormat BSON = EmbeddedFormat.BSON(new BSON());
-  }
-
   public static LogicalType DECIMAL(int scale, int precision) {
     return LogicalType.DECIMAL(new DecimalType(scale, precision));
   }
@@ -46,15 +41,15 @@ public class LogicalTypes {
   public static final LogicalType TIME_MICROS = LogicalType.TIME(new TimeType(true, TimeUnits.MICROS));
   public static final LogicalType TIMESTAMP_MILLIS = LogicalType.TIMESTAMP(new TimestampType(true, TimeUnits.MILLIS));
   public static final LogicalType TIMESTAMP_MICROS = LogicalType.TIMESTAMP(new TimestampType(true, TimeUnits.MICROS));
-  public static final LogicalType INT_8 = LogicalType.INTEGER(new IntType(8, true));
-  public static final LogicalType INT_16 = LogicalType.INTEGER(new IntType(16, true));
-  public static final LogicalType INT_32 = LogicalType.INTEGER(new IntType(32, true));
-  public static final LogicalType INT_64 = LogicalType.INTEGER(new IntType(64, true));
-  public static final LogicalType UINT_8 = LogicalType.INTEGER(new IntType(8, false));
-  public static final LogicalType UINT_16 = LogicalType.INTEGER(new IntType(16, false));
-  public static final LogicalType UINT_32 = LogicalType.INTEGER(new IntType(32, false));
-  public static final LogicalType UINT_64 = LogicalType.INTEGER(new IntType(64, false));
-  public static final LogicalType JSON = LogicalType.EMBEDDED(new EmbeddedType(EmbeddedFormats.JSON));
-  public static final LogicalType BSON = LogicalType.EMBEDDED(new EmbeddedType(EmbeddedFormats.BSON));
+  public static final LogicalType INT_8 = LogicalType.INTEGER(new IntType((byte) 8, true));
+  public static final LogicalType INT_16 = LogicalType.INTEGER(new IntType((byte) 16, true));
+  public static final LogicalType INT_32 = LogicalType.INTEGER(new IntType((byte) 32, true));
+  public static final LogicalType INT_64 = LogicalType.INTEGER(new IntType((byte) 64, true));
+  public static final LogicalType UINT_8 = LogicalType.INTEGER(new IntType((byte) 8, false));
+  public static final LogicalType UINT_16 = LogicalType.INTEGER(new IntType((byte) 16, false));
+  public static final LogicalType UINT_32 = LogicalType.INTEGER(new IntType((byte) 32, false));
+  public static final LogicalType UINT_64 = LogicalType.INTEGER(new IntType((byte) 64, false));
   public static final LogicalType NULL = LogicalType.NULL(new NullType());
+  public static final LogicalType JSON = LogicalType.JSON(new JsonType());
+  public static final LogicalType BSON = LogicalType.BSON(new BsonType());
 }

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -278,21 +278,16 @@ struct TimeType {
  * bitWidth must be 8, 16, 32, or 64.
  */
 struct IntType {
-  1: required i32 bitWidth
+  1: required byte bitWidth
   2: required bool isSigned
 }
 
-/** Embedded formats for logical EmbeddedType */
-struct JSON {}
-struct BSON {}
-union EmbeddedFormat {
-  1: JSON JSON
-  2: BSON BSON
+/** Embedded JSON logical type annotation */
+struct JsonType {
 }
 
-/** Embedded logical type annotation */
-struct EmbeddedType {
-  1: required EmbeddedFormat format
+/** Embedded BSON logical type annotation */
+struct BsonType {
 }
 
 /**
@@ -313,8 +308,9 @@ union LogicalType {
   8:  TimestampType TIMESTAMP // use ConvertedType TIMESTAMP_MICROS or TIMESTAMP_MILLIS
   // 9: reserved for INTERVAL
   10: IntType INTEGER         // use ConvertedType INT_* or UINT_*
-  11: EmbeddedType EMBEDDED   // use ConvertedType JSON or BSON
-  12: NullType NULL           // no compatible ConvertedType
+  11: NullType NULL           // no compatible ConvertedType
+  12: JsonType JSON           // use ConvertedType JSON
+  13: BsonType BSON           // use ConvertedType BSON
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -175,11 +175,6 @@ enum ConvertedType {
    */
   INTERVAL = 21;
 
-  /**
-   * Annotates a column that is always null
-   * Sometimes when discovering the schema of existing data
-   * values are always null
-   */
   NULL = 25;
 }
 
@@ -237,6 +232,13 @@ struct MapType {}
 struct ListType {}
 struct EnumType {}
 struct DateType {}
+
+/**
+ * Logical type to annotate a column that is always null.
+ *
+ * Sometimes when discovering the schema of existing data values are always
+ * null and the physical type is assumed.
+ */
 struct NullType {}
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -326,7 +326,7 @@ union LogicalType {
   8:  TimestampType TIMESTAMP // use ConvertedType TIMESTAMP_MICROS or TIMESTAMP_MILLIS
   // 9: reserved for INTERVAL
   10: IntType INTEGER         // use ConvertedType INT_* or UINT_*
-  11: NullType NONE           // no compatible ConvertedType
+  11: NullType UNKNOWN        // no compatible ConvertedType
   12: JsonType JSON           // use ConvertedType JSON
   13: BsonType BSON           // use ConvertedType BSON
 }

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -174,8 +174,6 @@ enum ConvertedType {
    * particular timezone or date.
    */
   INTERVAL = 21;
-
-  NULL = 25;
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -234,8 +234,9 @@ struct DateType {}    // allowed for INT32
 /**
  * Logical type to annotate a column that is always null.
  *
- * Sometimes when discovering the schema of existing data values are always
- * null and the physical type is assumed.
+ * Sometimes when discovering the schema of existing data, values are always
+ * null and the physical type can't be determined. This annotation signals
+ * the case where the physical type was guessed from all null values.
  */
 struct NullType {}    // allowed for any physical type, only null values stored
 

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -231,6 +231,90 @@ struct Statistics {
    6: optional binary min_value;
 }
 
+/** Empty structs to use as logical type annotations */
+struct StringType {}
+struct MapType {}
+struct ListType {}
+struct EnumType {}
+struct DateType {}
+struct NullType {}
+
+/**
+ * Decimal logical type annotation
+ *
+ * To maintain forward-compatibility in v1, implementations using this logical
+ * type must also set scale and precision on the annotated SchemaElement.
+ */
+struct DecimalType {
+  1: required i32 scale
+  2: required i32 precision
+}
+
+/** Time units for logical types */
+struct MilliSeconds {}
+struct MicroSeconds {}
+union TimeUnit {
+  1: MilliSeconds MILLIS
+  2: MicroSeconds MICROS
+}
+
+/** Timestamp logical type annotation */
+struct TimestampType {
+  1: required bool isAdjustedToUTC
+  2: required TimeUnit unit
+}
+
+/** Time logical type annotation */
+struct TimeType {
+  1: required bool isAdjustedToUTC
+  2: required TimeUnit unit
+}
+
+/**
+ * Integer logical type annotation
+ *
+ * bitWidth must be 8, 16, 32, or 64.
+ */
+struct IntType {
+  1: required i32 bitWidth
+  2: required bool isSigned
+}
+
+/** Embedded formats for logical EmbeddedType */
+struct JSON {}
+struct BSON {}
+union EmbeddedFormat {
+  1: JSON JSON
+  2: BSON BSON
+}
+
+/** Embedded logical type annotation */
+struct EmbeddedType {
+  1: required EmbeddedFormat format
+}
+
+/**
+ * LogicalType annotations to replace ConvertedType.
+ *
+ * To maintain compatibility, implementations using LogicalType for a
+ * SchemaElement must also set the corresponding ConvertedType from the
+ * following table.
+ */
+union LogicalType {
+  1:  StringType STRING       // use ConvertedType UTF8 if encoding is UTF-8
+  2:  MapType MAP             // use ConvertedType MAP
+  3:  ListType LIST           // use ConvertedType LIST
+  4:  EnumType ENUM           // use ConvertedType ENUM
+  5:  DecimalType DECIMAL     // use ConvertedType DECIMAL
+  6:  DateType DATE           // use ConvertedType DATE
+  7:  TimeType TIME           // use ConvertedType TIME_MICROS or TIME_MILLIS
+  8:  TimestampType TIMESTAMP // use ConvertedType TIMESTAMP_MICROS or TIMESTAMP_MILLIS
+  // 9: reserved for INTERVAL
+  10: IntType INTEGER         // use ConvertedType INT_* or UINT_*
+  11: EmbeddedType EMBEDDED   // use ConvertedType JSON or BSON
+  12: NullType NULL           // no compatible ConvertedType
+}
+
 /**
  * Represents a element inside a schema definition.
  *  - if it is a group (inner node) then type is undefined and num_children is defined
@@ -278,6 +362,13 @@ struct SchemaElement {
    */
   9: optional i32 field_id;
 
+  /**
+   * The logical type of this SchemaElement; only valid for primitives.
+   *
+   * LogicalType replaces ConvertedType, but ConvertedType is still required
+   * for some logical types to ensure forward-compatibility in format v1.
+   */
+  10: optional LogicalType logicalType
 }
 
 /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -225,11 +225,11 @@ struct Statistics {
 }
 
 /** Empty structs to use as logical type annotations */
-struct StringType {}
-struct MapType {}
-struct ListType {}
-struct EnumType {}
-struct DateType {}
+struct StringType {}  // allowed for BINARY, must be encoded with UTF-8
+struct MapType {}     // see LogicalTypes.md
+struct ListType {}    // see LogicalTypes.md
+struct EnumType {}    // allowed for BINARY, must be encoded with UTF-8
+struct DateType {}    // allowed for INT32
 
 /**
  * Logical type to annotate a column that is always null.
@@ -237,13 +237,15 @@ struct DateType {}
  * Sometimes when discovering the schema of existing data values are always
  * null and the physical type is assumed.
  */
-struct NullType {}
+struct NullType {}    // allowed for any physical type, only null values stored
 
 /**
  * Decimal logical type annotation
  *
  * To maintain forward-compatibility in v1, implementations using this logical
  * type must also set scale and precision on the annotated SchemaElement.
+ *
+ * Allowed for physical types: INT32, INT64, FIXED, and BINARY
  */
 struct DecimalType {
   1: required i32 scale
@@ -258,13 +260,21 @@ union TimeUnit {
   2: MicroSeconds MICROS
 }
 
-/** Timestamp logical type annotation */
+/**
+ * Timestamp logical type annotation
+ *
+ * Allowed for physical types: INT64
+ */
 struct TimestampType {
   1: required bool isAdjustedToUTC
   2: required TimeUnit unit
 }
 
-/** Time logical type annotation */
+/**
+ * Time logical type annotation
+ *
+ * Allowed for physical types: INT32 (millis), INT64 (micros)
+ */
 struct TimeType {
   1: required bool isAdjustedToUTC
   2: required TimeUnit unit
@@ -274,17 +284,27 @@ struct TimeType {
  * Integer logical type annotation
  *
  * bitWidth must be 8, 16, 32, or 64.
+ *
+ * Allowed for physical types: INT32, INT64
  */
 struct IntType {
   1: required byte bitWidth
   2: required bool isSigned
 }
 
-/** Embedded JSON logical type annotation */
+/**
+ * Embedded JSON logical type annotation
+ *
+ * Allowed for physical types: BINARY
+ */
 struct JsonType {
 }
 
-/** Embedded BSON logical type annotation */
+/**
+ * Embedded BSON logical type annotation
+ *
+ * Allowed for physical types: BINARY
+ */
 struct BsonType {
 }
 
@@ -306,7 +326,7 @@ union LogicalType {
   8:  TimestampType TIMESTAMP // use ConvertedType TIMESTAMP_MICROS or TIMESTAMP_MILLIS
   // 9: reserved for INTERVAL
   10: IntType INTEGER         // use ConvertedType INT_* or UINT_*
-  11: NullType NULL           // no compatible ConvertedType
+  11: NullType NONE           // no compatible ConvertedType
   12: JsonType JSON           // use ConvertedType JSON
   13: BsonType BSON           // use ConvertedType BSON
 }


### PR DESCRIPTION
This commit adds a `LogicalType` union and a field for this logical type to `SchemaElement`. Adding a new structure for logical types is needed for a few reasons:

1. Adding to the ConvertedType enum is not forward-compatible. Adding new types to the `LogicalType` union is forward-compatible.
2. Using a struct for each type allows additional metadata, like `isAdjustedToUTC`, without adding more fields to `SchemaElement` that don't apply to all types.
3. Types without additional metadata can be updated later. For example, adding an `encoding` field to `StringType` when it is needed.