### PR TITLE
PARQUET-974: Add a special ColumnOrder for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@
 
 thrift:
 	mkdir -p generated
-	thrift --gen cpp -o generated src/thrift/parquet.thrift 
-	thrift --gen java -o generated src/thrift/parquet.thrift 
+	thrift --gen cpp -o generated src/main/thrift/parquet.thrift
+	thrift --gen java -o generated src/main/thrift/parquet.thrift

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -578,8 +578,9 @@ struct RowGroup {
   4: optional list<SortingColumn> sorting_columns
 }
 
-/** Empty struct to signal the order defined by the physical or logical type */
+/** Empty structs to signal the order defined by the physical or logical type */
 struct TypeDefinedOrder {}
+struct InvalidOrder {}
 
 /**
  * Union to specify the order used for min, max, and sorting values in a column.
@@ -588,11 +589,16 @@ struct TypeDefinedOrder {}
  * * TypeDefinedOrder - the column uses the order defined by its logical or
  *                      physical type (if there is no logical type).
  *
+ * * InvalidOrder     - the column uses an invalid order that no reader should support.
+ *                      This order can be used to test logic to exclude unsupported orders
+ *                      and should not be used otherwise.
+ *
  * If the reader does not support the value of this union, min and max stats
  * for this column should be ignored.
  */
 union ColumnOrder {
-  1: TypeDefinedOrder TYPE_ORDER;
+  1: TypeDefinedOrder TYPE_ORDER
+  2: InvalidOrder INVALID_ORDER
 }
 
 /**


### PR DESCRIPTION
PR #46 introduced ColumnOrder with the limitation that a reader should
ignore stats for a column if the corresponding ColumnOrder in
FileMetaData contains an unknown value.

This change adds a special column order 'InvalidOrder' that can be used
to in tests and should not be used otherwise.

This change also fixes the paths in Makefile.