### PR TITLE
PARQUET-1102: Fix Travis CI builds for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: precise
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq protobuf-compiler


### PR DESCRIPTION
Travis CI migrated the default Ubuntu image version from precise to trusty on Sep 1st, 2017. This is probably the reason why all PR builds sent after Sep 1st failed. This PR tries to work around this issue by sticking to Ubuntu precise. We should migrate the build to Ubuntu trusty later, though.