### PR TITLE
encryption size field added in PageHeader

### DIFF
--- a/src/thrift/parquet.thrift
+++ b/src/thrift/parquet.thrift
@@ -408,16 +408,19 @@ struct PageHeader {
   /** Compressed page size in bytes (not including this header) **/
   3: required i32 compressed_page_size
 
+  /** Encrypted page size in bytes (not including this header) **/
+  4: optional i32 encrypted_page_size
+
   /** 32bit crc for the data below. This allows for disabling checksumming in HDFS
    *  if only a few pages needs to be read
    **/
-  4: optional i32 crc
+  5: optional i32 crc
 
   // Headers for page specific data.  One only will be set.
-  5: optional DataPageHeader data_page_header;
-  6: optional IndexPageHeader index_page_header;
-  7: optional DictionaryPageHeader dictionary_page_header;
-  8: optional DataPageHeaderV2 data_page_header_v2;
+  6: optional DataPageHeader data_page_header;
+  7: optional IndexPageHeader index_page_header;
+  8: optional DictionaryPageHeader dictionary_page_header;
+  9: optional DataPageHeaderV2 data_page_header_v2;
 }
 
 /**


### PR DESCRIPTION
Added new field **encrypted_page_size** to support block encryption in parquet-mr project.