### PR TITLE
PARQUET-1351: Travis builds fail for parquet-format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ before_install:
   - tar zxf thrift-0.9.3.tar.gz
   - cd thrift-0.9.3
   - chmod +x ./configure
-  - ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-erlang
+  - ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-erlang --without-php --without-nodejs
   - sudo make install
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@
 # under the License.
 
 language: java
-dist: precise
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq protobuf-compiler

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,9 @@
   </developers>
 
   <properties>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <targetJavaVersion>1.8</targetJavaVersion>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>${targetJavaVersion}</maven.compiler.target>
     <shade.prefix>shaded.parquet</shade.prefix>
     <thrift.executable>thrift</thrift.executable>
     <thrift.version>0.9.3</thrift.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,8 @@
   </developers>
 
   <properties>
-    <targetJavaVersion>1.8</targetJavaVersion>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>${targetJavaVersion}</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
     <shade.prefix>shaded.parquet</shade.prefix>
     <thrift.executable>thrift</thrift.executable>
     <thrift.version>0.9.3</thrift.version>


### PR DESCRIPTION
Use default (latest) distribution for Travis (as of now Trusty) to make tests pass. Looks like for Precise JDK 1.7 is the default Java version, where TLSv1 is the default, and it is not supported by Maven Central anymore. With Trusty, the build runs with JDK 1.8, and tests pass.