### PR TITLE
PARQUET-1428: Move columnar encryption into its feature branch 

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -901,22 +901,11 @@ struct FileMetaData {
 struct AesGcmV1 {
   /** Retrieval metadata of AAD used for encryption of pages and structures **/
   1: optional binary aad_metadata
-
-  /** If file IVs are comprised of a fixed part, and variable parts
-   *  (e.g. counter), keep the fixed part here **/
-  2: optional binary iv_prefix
- 
 }
 
 struct AesGcmCtrV1 {
   /** Retrieval metadata of AAD used for encryption of structures **/
   1: optional binary aad_metadata
-
-  /** If file IVs are comprised of a fixed part, and variable parts
-   *  (e.g. counter), keep the fixed part here **/
-  2: optional binary gcm_iv_prefix
-
-  3: optional binary ctr_iv_prefix
 }
 
 union EncryptionAlgorithm {
@@ -936,5 +925,10 @@ struct FileCryptoMetaData {
 
   /** Offset of Parquet footer (encrypted, or plaintext) **/
   4: required i64 footer_offset
+  
+  /** If file IVs are comprised of a fixed part,
+   *  and variable parts (random or counter), keep the fixed
+   *  part here **/
+  5: optional binary iv_prefix
 }
 

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -725,13 +725,6 @@ struct RowGroup {
    * The sorting columns can be a subset of all the columns.
    */
   4: optional list<SortingColumn> sorting_columns
-
-  /** Byte offset from beginning of file to first page (data or dictionary)
-   * in this row group **/
-  5: optional i64 file_offset
-
-  /** Total byte size of all compressed column data in this row group **/
-  6: optional i64 total_compressed_size
 }
 
 /** Empty struct to signal the order defined by the physical or logical type */

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -662,22 +662,6 @@ struct ColumnMetaData {
   13: optional list<PageEncodingStats> encoding_stats;
 }
 
-struct EncryptionWithFooterKey {
-}
-
-struct EncryptionWithColumnKey {
-  /** Column path in schema **/
-  1: required list<string> path_in_schema
-  
-  /** Retrieval metadata of the column-specific key **/
-  2: optional binary column_key_metadata
-}
-
-union ColumnCryptoMetaData {
-  1: EncryptionWithFooterKey ENCRYPTION_WITH_FOOTER_KEY
-  2: EncryptionWithColumnKey ENCRYPTION_WITH_COLUMN_KEY
-}
-
 struct ColumnChunk {
   /** File where column data is stored.  If not set, assumed to be same file as
     * metadata.  This path is relative to the current file.
@@ -704,9 +688,6 @@ struct ColumnChunk {
 
   /** Size of ColumnChunk's ColumnIndex, in bytes **/
   7: optional i32 column_index_length
-  
-  /** Crypto metadata of encrypted columns **/
-  8: optional ColumnCryptoMetaData crypto_meta_data
 }
 
 struct RowGroup {
@@ -896,39 +877,5 @@ struct FileMetaData {
    * regardless of column_orders.
    */
   7: optional list<ColumnOrder> column_orders;
-}
-
-struct AesGcmV1 {
-  /** Retrieval metadata of AAD used for encryption of pages and structures **/
-  1: optional binary aad_metadata
-}
-
-struct AesGcmCtrV1 {
-  /** Retrieval metadata of AAD used for encryption of structures **/
-  1: optional binary aad_metadata
-}
-
-union EncryptionAlgorithm {
-  1: AesGcmV1 AES_GCM_V1
-  2: AesGcmCtrV1 AES_GCM_CTR_V1
-}
-
-struct FileCryptoMetaData {
-  1: required EncryptionAlgorithm encryption_algorithm
-  
-  /** Parquet footer can be encrypted, or left as plaintext **/
-  2: required bool encrypted_footer
-    
-  /** Retrieval metadata of key used for encryption of footer, 
-   *  and (possibly) columns **/
-  3: optional binary footer_key_metadata
-
-  /** Offset of Parquet footer (encrypted, or plaintext) **/
-  4: required i64 footer_offset
-  
-  /** If file IVs are comprised of a fixed part,
-   *  and variable parts (random or counter), keep the fixed
-   *  part here **/
-  5: optional binary iv_prefix
 }
 


### PR DESCRIPTION
Revert columnar encryption changes for parquet-format release.

Since we don't have any signed-off spec for columnar encryption, and the spec is in fact still changing, revert these PRs and continue the development of columnar encryption on separate feature branch. This branch should be merged once the spec is signed off and it is ready to be released, this way this doesn't hinder parquet-format release.