### PR TITLE
PARQUET-1437: Misleading comment in parquet.thrift

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -903,8 +903,9 @@ struct FileMetaData {
 
   /**
    * Sort order used for the min_value and max_value fields of each column in
-   * this file. Each sort order corresponds to one column, determined by its
-   * position in the list, matching the position of the column in the schema.
+   * this file. Sort orders are listed in the order matching the columns in the
+   * schema. The indexes are not necessary the same though, because only leaf
+   * nodes of the schema are represented in the list of sort orders.
    *
    * Without column_orders, the meaning of the min_value and max_value fields is
    * undefined. To ensure well-defined behaviour, if min_value and max_value are


### PR DESCRIPTION
The documentation for list<ColumnOrder> column_orders stated that "Each
sort order corresponds to one column, determined by its position in the
list, matching the position of the column in the schema."

However, in reality, while the order of elements in these two
lists (schema and sort order) are the same, only leaf nodes are
represented in the list of sort orders, so the positions do not match.