### PR TITLE
PARQUET-1539: Clarify CRC checksum in page header

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ the reasoning behind adding these to the format.
 
 ## Checksumming
 Data pages can be individually checksummed.  This allows disabling of checksums at the
-HDFS file level, to better support single row lookups.
+HDFS file level, to better support single row lookups. Data page checksums are calculated
+using the standard CRC32 algorithm on the compressed data of a page (not including the
+page header itself).
 
 ## Error recovery
 If the file metadata is corrupt, the file is lost.  If the column metadata is corrupt,

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -606,9 +606,25 @@ struct PageHeader {
 
   /** The 32bit CRC for the page, to be be calculated as follows:
    * - Using the standard CRC32 algorithm
-   * - On the data only, i.e. this header should not be included
-   * - On the compressed version of the data (unless no compression scheme is
-   *   specified for the page)
+   * - On the data only, i.e. this header should not be included. 'Data'
+   *   hereby refers to the concatenation of the repetition levels, the
+   *   definition levels and the column value, in this exact order.
+   * - On the encoded versions of the repetition levels, definition levels and
+   *   column values
+   * - On the compressed versions of the repetition levels, definition levels
+   *   and column values where possible;
+   *   - For v1 data pages, the repetition levels, definition levels and column
+   *     values are always compressed together. If a compression scheme is
+   *     specified, the CRC shall be calculated on the compressed version of
+   *     this concatenation. If no compression scheme is specified, the CRC
+   *     shall be calculated on the uncompressed version of this concatenation.
+   *   - For v2 data pages, the repetition levels and definition levels are
+   *     handled separately from the data and are never compressed (only
+   *     encoded). If a compression scheme is specified, the CRC shall be
+   *     calculated on the concatenation of the uncompressed repetition levels,
+   *     uncompressed definition levels and the compressed column values.
+   *     If no compression scheme is specified, the CRC shall be calculated on
+   *     the uncompressed concatenation.
    * If enabled, this allows for disabling checksumming in HDFS if only a few
    * pages need to be read.
    **/

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -604,8 +604,13 @@ struct PageHeader {
   /** Compressed page size in bytes (not including this header) **/
   3: required i32 compressed_page_size
 
-  /** 32bit crc for the data below. This allows for disabling checksumming in HDFS
-   *  if only a few pages needs to be read
+  /** The 32bit CRC for the page, to be be calculated as follows:
+   * - Using the standard CRC32 algorithm
+   * - On the data only, i.e. this header should not be included
+   * - On the compressed version of the data (unless no compression scheme is
+   *   specified for the page)
+   * If enabled, this allows for disabling checksumming in HDFS if only a few
+   * pages need to be read.
    **/
   4: optional i32 crc
 


### PR DESCRIPTION
Although a page-level CRC field is defined in the Thrift specification, currently neither parquet-cpp nor parquet-mr leverage it. Moreover, the comment in the Thrift specification reads ‘32bit crc for the data below’, which is somewhat ambiguous to what exactly constitutes the ‘data’ that the checksum should be calculated on. To ensure backward- and cross-compatibility of Parquet readers/writes which do want to leverage the CRC checksums, the format should specify exactly how and on what data the checksum should be calculated.

**TLDR proposal:** The checksum will be calculated using the standard CRC32 algorithm, whereby the checksum is to be calculated on the data only, not including the page header itself (simple implementation) and the checksum will be calculated on compressed data (inherently faster, likely better triaging). 

## Alternatives
There are three main choices to be made here:

1. Which variant of CRC32 to use
2. Whether to include the page header itself in the checksum calculation
3. Whether to calculate the checksum on uncompressed or compressed data

### Algorithm
The CRC field holds a 32-bit value. There are many different variants of the original CRC32 algorithm, each producing different values for the same input. For ease of implementation we propose to use the standard CRC32 algorithm.

### Including page header
The page header itself could be included in the checksum calculation using an approach similar to what TCP does, whereby the checksum field itself is zeroed out before calculating the checksum that will be inserted there. Evidently, including the page header is better in the sense that it increases the data covered by the checksum. However, from an implementation perspective, not including it is likely easier. Furthermore, given the relatively small size of the page header compared to the page itself, simply not including it will likely be good enough.

### Compressed vs uncompressed
**Compressed**
Pros
- Inherently faster, less data to operate on
- Potentially better triaging when determining where a corruption may have been introduced, as checksum is calculated in a later stage

Cons
- We have to trust both the encoding stage and the compression stage

**Uncompressed**
Pros
- We only have to trust the encoding stage
- Possibly able to detect more corruptions, as data is checksummed at earliest possible moment, checksum will be more sensitive to corruption introduced further down the line

Cons
- Inherently slower, more data to operate on, always need to decompress first
- Potentially harder triaging, more stages in which corruption could have been introduced