### PR TITLE
PARQUET-1561: Inconsistencies in the Delta Encoding specification

### DIFF
--- a/Encodings.md
+++ b/Encodings.md
@@ -153,7 +153,9 @@ repetition and definition levels.
 ### <a name="DELTAENC"></a>Delta Encoding (DELTA_BINARY_PACKED = 5)
 Supported Types: INT32, INT64
 
-This encoding is adapted from the Binary packing described in ["Decoding billions of integers per second through vectorization"](http://arxiv.org/pdf/1209.2137v5.pdf) by D. Lemire and L. Boytsov
+This encoding is adapted from the Binary packing described in ["Decoding billions of integers per second through vectorization"](http://arxiv.org/pdf/1209.2137v5.pdf) by D. Lemire and L. Boytsov.
+
+In delta encoding we make use of variable length integers for storing various numbers (not the deltas themselves). For unsigned values, we use ULEB128, which is the unsigned version of LEB128 ([https://en.wikipedia.org/wiki/LEB128#Unsigned_LEB128]). For signed values, we use zigzag encoding ([https://developers.google.com/protocol-buffers/docs/encoding#signed-integers]) to map negative values to positive ones and apply ULEB128 on the result.
 
 Delta encoding consists of a header followed by blocks of delta encoded values binary packed. Each block is made of miniblocks, each of them binary packed with its own bit width.
 

--- a/Encodings.md
+++ b/Encodings.md
@@ -186,9 +186,9 @@ To encode a block, we will:
 
 Having multiple blocks allows us to adapt to changes in the data by changing the frame of reference (the min delta) which can result in smaller values after the subtraction which, again, means we can store them with a lower bit width.
 
-If there are not enough values to fill the last miniblock, we pad the miniblock so that its length is always the number of values in a full miniblock multiplied by the bit width. The values of the padding bits are unspecified.
+If there are not enough values to fill the last miniblock, we pad the miniblock so that its length is always the number of values in a full miniblock multiplied by the bit width. The values of the padding bits should be zero, but readers must accept paddings consisting of arbitrary bits as well.
 
-If, in the last block, less than ```<number of miniblocks in a block>``` miniblocks are needed to store the values, the bytes storing the bit widths of the unneeded miniblocks are still present, but their values are unspecified. There are no additional padding bytes for the miniblock bodies though, as if their bit widths were 0. The reader knows when to stop reading by keeping track of the number of values read.
+If, in the last block, less than ```<number of miniblocks in a block>``` miniblocks are needed to store the values, the bytes storing the bit widths of the unneeded miniblocks are still present, their value should be zero, but readers must accept arbitrary values as well. There are no additional padding bytes for the miniblock bodies though, as if their bit widths were 0 (regardless of the actual byte values). The reader knows when to stop reading by keeping track of the number of values read.
 
 The following examples use 8 as the block size to keep the examples short, but in real cases it would be invalid.
 #### Example 1


### PR DESCRIPTION
Addressed most points in PARQUET-1561.
We should add examples containing multiple miniblocks and blocks.