### PR TITLE
PARQUET-1588: Bump to Apache Thrift 0.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ target
 dependency-reduced-pom.xml
 .classpath
 .project
+
+# IDE stuff
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq protobuf-compiler
   - sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
-  - wget -nv https://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
-  - tar zxf thrift-0.9.3.tar.gz
-  - cd thrift-0.9.3
+  - wget -nv https://archive.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz
+  - tar zxf thrift-0.12.0.tar.gz
+  - cd thrift-0.12.0
   - chmod +x ./configure
   - ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-erlang --without-php --without-nodejs
   - sudo make install

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <shade.prefix>shaded.parquet</shade.prefix>
     <thrift.executable>thrift</thrift.executable>
-    <thrift.version>0.9.3</thrift.version>
+    <thrift.version>0.12.0</thrift.version>
     <thrift-maven-plugin.version>0.10.0</thrift-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
`parquet-mr` is at Thrift 0.12.0 as well.

https://jira.apache.org/jira/browse/PARQUET-1507

This also fixes the CVE-2018-1320 https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-1320