### PR TITLE
PARQUET-1592: rename bloom filter hash

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -579,7 +579,7 @@ struct Murmur3Hash {}
  **/
 union BloomFilterHash {
   /** Murmur3 Hash Strategy. **/
-  1: Murmur3Hash MURMUR3HASH;
+  1: Murmur3Hash MURMUR3;
 }
 /**
   * Bloom filter header is stored at beginning of Bloom filter data of each column

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -572,14 +572,14 @@ union BloomFilterAlgorithm {
 /** Hash strategy type annotation. It uses Murmur3Hash_x64_128 from the original SMHasher
  * repo by Austin Appleby.
  **/
-struct Murmur3 {}
+struct Murmur3Hash {}
 /** 
  * The hash function used in Bloom filter. This function takes the hash of a column value
  * using plain encoding.
  **/
 union BloomFilterHash {
   /** Murmur3 Hash Strategy. **/
-  1: Murmur3 MURMUR3;
+  1: Murmur3Hash MURMUR3HASH;
 }
 /**
   * Bloom filter header is stored at beginning of Bloom filter data of each column


### PR DESCRIPTION
Rename bloom filter hash from murmur3 to murmur3hash.