### PR TITLE
PARUQET-1609: Update to use xxHash as hash strategy

### DIFF
--- a/BloomFilter.md
+++ b/BloomFilter.md
@@ -87,11 +87,11 @@ void Mask(uint32_t key, uint32_t mask[8]) {
 ```
 
 #### Hash Function
-The function used to hash values in the initial implementation is MurmurHash3[4], using
-the least-significant 64 bits of the 128-bit version of the function on the x86-64
-platform. Note that the function produces different values on different architectures, so
-implementors must be careful to use the version specific to x86-64. That function can be
-emulated on different platforms without difficulty.
+The function used to hash values in the initial implementation is xxHash[4], using
+the least-significant 64 bits version of the function on the x86-64 platform. Note that
+the function produces different values on different architectures, so implementors must
+be careful to use the version specific to x86-64. That function can be emulated on
+different platforms without difficulty.
 
 #### Build a Bloom filter
 The fact that exactly eight bits are checked during each lookup means that these filters
@@ -116,5 +116,5 @@ hash function.
 1. [Bloom filter introduction at Wiki](https://en.wikipedia.org/wiki/Bloom_filter)
 2. [Cache-, Hash- and Space-Efficient Bloom Filters](http://algo2.iti.kit.edu/documents/cacheefficientbloomfilters-jea.pdf)
 3. [A Reliable Randomized Algorithm for the Closest-Pair Problem](http://www.diku.dk/~jyrki/Paper/CP-11.4.1997.ps)
-4. [Murmur Hash at Wiki](https://en.wikipedia.org/wiki/MurmurHash)
+4. [xxHash](https://cyan4973.github.io/xxHash/)
 5. [Network Applications of Bloom Filters: A Survey](https://www.eecs.harvard.edu/~michaelm/postscripts/im2005b.pdf)

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -570,11 +570,6 @@ union BloomFilterAlgorithm {
   1: SplitBlockAlgorithm BLOCK;
 }
 
-/** Hash strategy type annotation. It uses Murmur3Hash_x64_128 from the original SMHasher
- * repo by Austin Appleby.
- **/
-struct Murmur3Hash {}
-
 /** Hash strategy type annotation. xxHash is an extremely fast non-cryptographic hash
  * algorithm. It uses 64 bits version of xxHash. 
  **/
@@ -585,8 +580,8 @@ struct XxHash {}
  * using plain encoding.
  **/
 union BloomFilterHash {
-  /** Murmur3 Hash Strategy. **/
-  1: Murmur3Hash MURMUR3;
+  /** xxHash Strategy. **/
+  1: XxHash XXHASH;
 }
 /**
   * Bloom filter header is stored at beginning of Bloom filter data of each column

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -569,10 +569,17 @@ union BloomFilterAlgorithm {
   /** Block-based Bloom filter. **/
   1: SplitBlockAlgorithm BLOCK;
 }
+
 /** Hash strategy type annotation. It uses Murmur3Hash_x64_128 from the original SMHasher
  * repo by Austin Appleby.
  **/
 struct Murmur3Hash {}
+
+/** Hash strategy type annotation. xxHash is an extremely fast non-cryptographic hash
+ * algorithm. It uses 64 bits version of xxHash. 
+ **/
+struct XxHash {}
+
 /** 
  * The hash function used in Bloom filter. This function takes the hash of a column value
  * using plain encoding.


### PR DESCRIPTION


### Jira

- My PR addresses Jira(https://issues.apache.org/jira/browse/PARQUET-1609) issue and references them in the PR "PARUQET-1609: Add xxHash as an option to bloom-filter hash strategy"


