### PR TITLE
PARQUET-1609: Specify which xxhash carefully

### DIFF
--- a/BloomFilter.md
+++ b/BloomFilter.md
@@ -108,9 +108,9 @@ void Mask(uint32_t key, uint32_t mask[8]) {
 
 #### Hash Function
 The function used to hash values in the initial implementation is
-[xxHash](https://cyan4973.github.io/xxHash/), using the least-significant 64 bits version of the
-function on the x86-64 platform. Note that a given variant, such as XXHash64, shall produces same
-output irrespective of the cpu/os used, though different variants may produce different values.
+[xxHash](https://cyan4973.github.io/xxHash/), using the function XXH64 with a
+seed of 0 and [following the specification version
+0.1.1](https://github.com/Cyan4973/xxHash/blob/v0.7.0/doc/xxhash_spec.md).
 
 #### Build a Bloom filter
 The fact that exactly eight bits are checked during each lookup means that these filters


### PR DESCRIPTION
The hash function "xxhash" is actually a number of different hash
functions including xxHash, XXH64, XXH32, and XXH3. Additionally,
these hash functions accept "seeds", as most modern hash functions do,
including MurmurHash variants.

This patch specifies that the BloomFilter hash function default is
XXH64 with a seed of 0. It omits the confusing note about the ISA and
different variants of xxHash, since XXH64 is apparently
architecture-independent.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-1609) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
