### PR TITLE
PARQUET-1627: Update specification so that legacy timestamp logical types can be written for local semantics as well

### DIFF
--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -282,6 +282,12 @@ counterpart, it must annotate an `int32`.
 type that is UTC normalized and has `MICROS` precision. Like the logical type
 counterpart, it must annotate an `int64`.
 
+Despite there is no exact corresponding ConvertedType for local time semantic,
+in order to support forward compatibility with those libraries, which annotated
+their local time with legacy `TIME_MICROS` and `TIME_MILLIS` annotation,
+Parquet writer implementation *must* annotate local time with legacy annotations too,
+as shown below.
+
 *Backward compatibility:*
 
 | ConvertedType | LogicalType |
@@ -313,11 +319,11 @@ counterpart, it must annotate an `int64`.
     <tr>
         <td rowspan="3">isAdjustedToUTC = false</td>
         <td>unit = MILLIS</td>
-        <td>-</td>
+        <td>TIME_MILLIS</td>
     </tr>
     <tr>
         <td>unit = MICROS</td>
-        <td>-</td>
+        <td>TIME_MICROS</td>
     </tr>
     <tr>
         <td>unit = NANOS</td>
@@ -452,6 +458,12 @@ type counterpart, it must annotate an `int64`.
 logical type that is UTC normalized and has `MICROS` precision. Like the logical
 type counterpart, it must annotate an `int64`.
 
+Despite there is no exact corresponding ConvertedType for local timestamp semantic,
+in order to support forward compatibility with those libraries, which annotated
+their local timestamps with legacy `TIMESTAMP_MICROS` and `TIMESTAMP_MILLIS` annotation,
+Parquet writer implementation *must* annotate local timestamps with legacy annotations too,
+as shown below.
+
 *Backward compatibility:*
 
 | ConvertedType | LogicalType |
@@ -483,11 +495,11 @@ type counterpart, it must annotate an `int64`.
     <tr>
         <td rowspan="3">isAdjustedToUTC = false</td>
         <td>unit = MILLIS</td>
-        <td>-</td>
+        <td>TIMESTAMP_MILLIS</td>
     </tr>
     <tr>
         <td>unit = MICROS</td>
-        <td>-</td>
+        <td>TIMESTAMP_MICROS</td>
     </tr>
     <tr>
         <td>unit = NANOS</td>

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -327,12 +327,12 @@ union LogicalType {
   5:  DecimalType DECIMAL     // use ConvertedType DECIMAL
   6:  DateType DATE           // use ConvertedType DATE
 
-  // use ConvertedType TIME_MICROS for TIME(isAdjustedToUTC = true, unit = MICROS)
-  // use ConvertedType TIME_MILLIS for TIME(isAdjustedToUTC = true, unit = MILLIS)
+  // use ConvertedType TIME_MICROS for TIME(isAdjustedToUTC = *, unit = MICROS)
+  // use ConvertedType TIME_MILLIS for TIME(isAdjustedToUTC = *, unit = MILLIS)
   7:  TimeType TIME
 
-  // use ConvertedType TIMESTAMP_MICROS for TIMESTAMP(isAdjustedToUTC = true, unit = MICROS)
-  // use ConvertedType TIMESTAMP_MILLIS for TIMESTAMP(isAdjustedToUTC = true, unit = MILLIS)
+  // use ConvertedType TIMESTAMP_MICROS for TIMESTAMP(isAdjustedToUTC = *, unit = MICROS)
+  // use ConvertedType TIMESTAMP_MILLIS for TIMESTAMP(isAdjustedToUTC = *, unit = MILLIS)
   8:  TimestampType TIMESTAMP
 
   // 9: reserved for INTERVAL


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
