### PR TITLE
PARQUET-1630: add empty compression union for Bloom filter

### DIFF
--- a/BloomFilter.md
+++ b/BloomFilter.md
@@ -264,6 +264,14 @@ union BloomFilterHash {
 }
 
 /**
+ * The compression used in the Bloom filter.
+ **/
+struct Uncompressed {}
+union BloomFilterCompression {
+  1: Uncompressed UNCOMPRESSED;
+}
+
+/**
   * Bloom filter header is stored at beginning of Bloom filter data of each column
   * and followed by its bitset.
   **/
@@ -274,6 +282,8 @@ struct BloomFilterPageHeader {
   2: required BloomFilterAlgorithm algorithm;
   /** The hash function used for Bloom filter. **/
   3: required BloomFilterHash hash;
+  /** The compression used in the Bloom filter **/
+  4: required BloomFilterCompression compression;
 }
 
 struct ColumnMetaData {

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -582,6 +582,15 @@ union BloomFilterHash {
   /** xxHash Strategy. **/
   1: XxHash XXHASH;
 }
+
+/**
+ * The compression used in the Bloom filter.
+ **/
+struct Uncompressed {}
+union BloomFilterCompression {
+  1: Uncompressed UNCOMPRESSED;
+}
+
 /**
   * Bloom filter header is stored at beginning of Bloom filter data of each column
   * and followed by its bitset.
@@ -593,6 +602,8 @@ struct BloomFilterHeader {
   2: required BloomFilterAlgorithm algorithm;
   /** The hash function used for Bloom filter. **/
   3: required BloomFilterHash hash;
+  /** The compression used in the Bloom filter **/
+  4: required BloomFilterCompression compression;
 }
 
 struct PageHeader {


### PR DESCRIPTION
Right now no compression methods are supported. For more on Bloom
filter compression, see Michael Mitzenmacher's "Compressed Bloom
Filters",
https://www.eecs.harvard.edu/~michaelm/NEWWORK/postscripts/cbf2.pdf