### PR TITLE
PARQUET-1672: [DOC] Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ There are many places in the format for compatible extensions:
 
 ## Contributing
 Comment on the issue and/or contact [the parquet-dev mailing list](http://mail-archives.apache.org/mod_mbox/parquet-dev/) with your questions and ideas.
-Changes to this core format definition are proposed and discussed in depth on the mailing list. You may also be interested in contributing to the Parquet-MR subproject, which contains all the Java-side implementation and APIs. See the "How To Contribute" section of the [Parquet-MR project](github.com/apache/parquet-mr)
+Changes to this core format definition are proposed and discussed in depth on the mailing list. You may also be interested in contributing to the Parquet-MR subproject, which contains all the Java-side implementation and APIs. See the "How To Contribute" section of the [Parquet-MR project](https://github.com/apache/parquet-mr#how-to-contribute)
 
 ## Code of Conduct
 


### PR DESCRIPTION
Link to "How To Contribute" section in Parquet-MR project would return
404 error as the URL would be incorrectly expanded to
https://github.com/apache/parquet-format/blob/master/github.com/apache/parquet-mr
instead of https://github.com/apache/parquet-mr which is the assumed
desired destination

This change should take one directly to the "How To Contribute" section
in the Parquet-MR README

	modified:   README.md

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet-1672](https://issues.apache.org/jira/browse/PARQUET-1672) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1672
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
