### PR TITLE
PARQUET-1708: Fix Thrift compiler warning

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -292,7 +292,7 @@ struct TimeType {
  * Allowed for physical types: INT32, INT64
  */
 struct IntType {
-  1: required byte bitWidth
+  1: required i8 bitWidth
   2: required bool isSigned
 }
 


### PR DESCRIPTION
### Jira
https://issues.apache.org/jira/browse/PARQUET-1708



