### PR TITLE
PARQUET-675: Specify Interval LogicalType

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -274,6 +274,23 @@ struct TimestampType {
   2: required TimeUnit unit
 }
 
+/** Interval units for logical types */
+struct YearMonth {}
+struct DayTime {}
+union IntervalUnit {
+  1: YearMonth YEAR_MONTH
+  2: DayTime DAY_TIME
+}
+
+/*
+ * Interval logical type annotation
+ *
+ * Allowed for physical types: INT32 (year_month), FIXED_LEN_BYTE_ARRAY(8) (day_time)
+ */
+struct IntervalType {
+  1: required IntervalUnit unit
+}
+
 /**
  * Time logical type annotation
  *
@@ -335,7 +352,8 @@ union LogicalType {
   // use ConvertedType TIMESTAMP_MILLIS for TIMESTAMP(isAdjustedToUTC = *, unit = MILLIS)
   8:  TimestampType TIMESTAMP
 
-  // 9: reserved for INTERVAL
+  // The interval type is not compatible with the legacy ConvertedType INTERVAL
+  9: IntervalType INTERVAL
   10: IntType INTEGER         // use ConvertedType INT_* or UINT_*
   11: NullType UNKNOWN        // no compatible ConvertedType
   12: JsonType JSON           // use ConvertedType JSON


### PR DESCRIPTION
I am working on the Parquet Rust implementation, specifically conversion with Arrow.
One of the outstanding items in the Parquet types is how to deal with interval types.

This PR proposes adding `LogicalType::Interval(IntervalType)`, which is compatible with Arrow. I have only made changes to the thrift file, as I'd like to get feedback on viability, before documenting the behaviour in the LogicalTypes.md.
Much of the detail is however below in this message.

The legacy `ConvertedType` has `INTERVAL`, but this interval is ambiguous for Arrow, because Arrow defines:
1. Interval::YearMonth: i32 representing the number of elapsed whole months
2. Interval::DayTime: i64 stored as 2 contiguous 32-bit integers, representing the number of elapsed days and milliseconds, respectively

@julienledem initially suggested deprecating `INTERVAL` by replacing it with 2 converted types in #43, but given that Parquet got logical types since then, we could offer a better alternative by using the `LogicalType::Interval(IntervalUnit)`alternative.

This would either be 32-bit or 64-bit based on the interval unit.
On the 64-bit representation, I'm not opinionated on whether we should use an INT64 or FiXED_LEN_BYTE_ARRAY(8). I suspect though that we initially used FIXED_LEN_BYTE_ARRAY(12) because there's no 96-bit primitive.

# Backward Compatibility with ConvertedType

We do not deprecate the `INTERVAL` converted type, as one could always convert the LogicalType value to either the first 4 bytes, or the last 8, depending on the IntervalUnit; and so write only those bytes.

We would mark converting from ConvertedType to LogicalType as undefined behaviour, because without any additional information on which of the 12 bytes are populated, readers could lose information (what Rust is currently doing).

implementations that rely on the old behaviour still have the option of populating both converted type and logical type, so they should not populate the logical type in this instance.
