### PR TITLE
PARQUET-2080: Deprecate RowGroup.file_offset

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -831,8 +831,12 @@ struct RowGroup {
    */
   4: optional list<SortingColumn> sorting_columns
 
-  /** Byte offset from beginning of file to first page (data or dictionary)
-   * in this row group **/
+  /** Deprecated: This field might contain invalid values in certain cases so it
+   * is concidered not reliable.
+   * Use ColumnMetaData.data_page_offset of the first column chunk or
+   * ColumnMetaData.dictionary_page_offset of the same one if it is dictionary
+   * encoded.
+   */
   5: optional i64 file_offset
 
   /** Total byte size of all compressed (and potentially encrypted) column data 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
