### PR TITLE
Fix typo under "Unsigned Integers"

### DIFF
--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -129,7 +129,7 @@ Implementations must not write values that are larger than the annotation
 allows.
 
 `INT(8, false)`, `INT(16, false)`, and `INT(32, false)` must annotate an `int32` primitive type and
-`INT(64, true)` must annotate an `int64` primitive type.
+`INT(64, false)` must annotate an `int64` primitive type.
 
 The sort order used for unsigned integer types is unsigned.
 


### PR DESCRIPTION
I'm pretty sure that, under "Unsigned Integers", we should say

> …and `INT(64, false)` must annotate…

rather than

> …and `INT(64, true)` must annotate…

Make sure you have checked _all_ steps below.