### PR TITLE
PARQUET-2222: RLE encoding spec incorrect for v2 data pages

### DIFF
--- a/Encodings.md
+++ b/Encodings.md
@@ -68,7 +68,7 @@ This encoding uses a combination of bit-packing and run length encoding to more 
 The grammar for this encoding looks like this, given a fixed bit-width known in advance:
 ```
 rle-bit-packed-hybrid: <length> <encoded-data>
-// length is not written for definition/repetition levels in v2 data pages since it is duplicated in the DataPageHeaderV2
+// length is not always prepended, please check the table below for more detail
 length := length of the <encoded-data> in bytes stored as 4 bytes little endian (unsigned int32)
 encoded-data := <run>*
 run := <bit-packed-run> | <rle-run>
@@ -123,6 +123,23 @@ data:
 * Repetition and definition levels
 * Dictionary indices
 * Boolean values in data pages, as an alternative to PLAIN encoding
+
+Whether prepending the four-byte `length` to the `encoded-data` is summarized as the table below:
+```
++--------------+------------------------+-----------------+
+| Page kind    | RLE-encoded data kind  | Prepend length? |
++--------------+------------------------+-----------------+
+| Data page v1 | Definition levels      | Y               |
+|              | Repetition levels      | Y               |
+|              | Dictionary indices     | N               |
+|              | Boolean values         | Y               |
++--------------+------------------------+-----------------+
+| Data page v2 | Definition levels      | N               |
+|              | Repetition levels      | N               |
+|              | Dictionary indices     | N               |
+|              | Boolean values         | Y               |
++--------------+------------------------+-----------------+
+```
 
 ### <a name="BITPACKED"></a>Bit-packed (Deprecated) (BIT_PACKED = 4)
 

--- a/Encodings.md
+++ b/Encodings.md
@@ -119,7 +119,7 @@ repeated-value := value that is repeated, using a fixed-width of round-up-to-nex
 Note that the RLE encoding method is only supported for the following types of
 data:
 
-* Repetition and definition levels
+* Repetition and definition levels (Please note that the 4-byte length of the `<encoded-data>` is not prefixed in the data page v2 as it is duplicated in the `DataPageHeaderV2`)
 * Dictionary indices
 * Boolean values in data pages, as an alternative to PLAIN encoding
 

--- a/Encodings.md
+++ b/Encodings.md
@@ -68,6 +68,7 @@ This encoding uses a combination of bit-packing and run length encoding to more 
 The grammar for this encoding looks like this, given a fixed bit-width known in advance:
 ```
 rle-bit-packed-hybrid: <length> <encoded-data>
+// length is not written for definition/repetition levels in v2 data pages since it is duplicated in the DataPageHeaderV2
 length := length of the <encoded-data> in bytes stored as 4 bytes little endian (unsigned int32)
 encoded-data := <run>*
 run := <bit-packed-run> | <rle-run>
@@ -119,7 +120,7 @@ repeated-value := value that is repeated, using a fixed-width of round-up-to-nex
 Note that the RLE encoding method is only supported for the following types of
 data:
 
-* Repetition and definition levels (Please note that the 4-byte length of the `<encoded-data>` is not prefixed in the data page v2 as it is duplicated in the `DataPageHeaderV2`)
+* Repetition and definition levels
 * Dictionary indices
 * Boolean values in data pages, as an alternative to PLAIN encoding
 


### PR DESCRIPTION
**JIRA:**
https://issues.apache.org/jira/browse/PARQUET-2222

**Problem:**
The spec (https://github.com/apache/parquet-format/blob/master/Encodings.md#run-length-encoding--bit-packing-hybrid-rle--3) has this:
```
rle-bit-packed-hybrid: <length> <encoded-data>
length := length of the <encoded-data> in bytes stored as 4 bytes little endian (unsigned int32)
```
But the length is actually prepended only in v1 data pages, not in v2 data pages.

**Implementation:**
parquet-mr: https://github.com/apache/parquet-mr/blob/master/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterV2.java#L41
parquet-cpp: https://github.com/apache/arrow/blob/main/cpp/src/parquet/column_writer.cc#L848

**Proposal:**
Explicitly get rid of the confusion in the RLE encoding spec.