### PR TITLE
PARQUET-2264: Allow scale == precision for DecimalType

### DIFF
--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -219,7 +219,7 @@ decimal point, and the precision stores the maximum number of digits supported
 in the unscaled value.
 
 If not specified, the scale is 0. Scale must be zero or a positive integer less
-than the precision. Precision is required and must be a non-zero positive
+than or equal to the precision. Precision is required and must be a non-zero positive
 integer. A precision too large for the underlying type (see below) is an error.
 
 `DECIMAL` can be used to annotate the following types:

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -245,6 +245,9 @@ struct NullType {}    // allowed for any physical type, only null values stored
 /**
  * Decimal logical type annotation
  *
+ * Scale must be zero or a positive integer less than or equal to the precision.
+ * Precision must be a non-zero positive integer.
+ *
  * To maintain forward-compatibility in v1, implementations using this logical
  * type must also set scale and precision on the annotated SchemaElement.
  *


### PR DESCRIPTION
The majority of implementations allow for scale == precision.
    
See https://github.com/apache/arrow-rs/pull/1607 for further motivation.
