### PR TITLE
PARQUET-2299: Use `true` instead of `1` as default value for `is_compressed` bool field

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -581,7 +581,7 @@ struct DataPageHeaderV2 {
   definition_levels_byte_length + repetition_levels_byte_length + 1 and compressed_page_size (included)
   is compressed with the compression_codec.
   If missing it is considered compressed */
-  7: optional bool is_compressed = 1;
+  7: optional bool is_compressed = true;
 
   /** optional statistics for the data in this page **/
   8: optional Statistics statistics;


### PR DESCRIPTION
I noticed that the default value for the optional boolean `is_compressed` field of the `DataPageHeaderV2` struct has a default value of `1`. According to the Thrift docs a boolean value is either `true` or `false`. 

This currently works because the Apache Thrift compiler internally handles bools as ints:
- https://github.com/apache/thrift/blob/3880a09565a9a1dad028b3679746eafac268c819/compiler/cpp/src/thrift/thriftl.ll#L208-L209
- https://github.com/apache/thrift/blob/3880a09565a9a1dad028b3679746eafac268c819/compiler/cpp/src/thrift/main.cc#L748

It may however not work with other Thrift compilers that are more strict about this.

Based on the docs and [a test](https://github.com/apache/thrift/blob/3880a09565a9a1dad028b3679746eafac268c819/test/ThriftTest.thrift#L406) in the Thrift repository it seems that using `true` here is the correct way of defining a default for an optional bool field.

