### PR TITLE
PARQUET-2362: Clarify parquet encoding

### DIFF
--- a/Encodings.md
+++ b/Encodings.md
@@ -54,7 +54,7 @@ using the [RLE/Bit-Packing Hybrid](#RLE) encoding. If the dictionary grows too b
 or number of distinct values, the encoding will fall back to the plain encoding. The dictionary page is
 written first, before the data pages of the column chunk.
 
-Dictionary page format: the entries in the dictionary - in dictionary order - using the [plain](#PLAIN) encoding.
+Dictionary page format: the entries in the dictionary using the [plain](#PLAIN) encoding.
 
 Data page format: the bit width used to encode the entry ids stored as 1 byte (max bit width = 32),
 followed by the values encoded using RLE/Bit packed described above (with the given bit width).
@@ -148,7 +148,7 @@ Whether prepending the four-byte `length` to the `encoded-data` is summarized as
 
 This is a bit-packed only encoding, which is deprecated and will be replaced by the [RLE/bit-packing](#RLE) hybrid encoding.
 Each value is encoded back to back using a fixed width.
-There is no padding between values (except for the last byte) which is padded with 0s.
+There is no padding between values (except for the last byte, which is padded with 0s).
 For example, if the max repetition level was 3 (2 bits) and the max definition level as 3
 (2 bits), to encode 30 values, we would have 30 * 2 = 60 bits = 8 bytes.
 


### PR DESCRIPTION
> Dictionary page format: the entries in the dictionary - in dictionary order - using the [plain](#PLAIN) encoding.

The dictionary entries are not sorted (or at least not always sorted).

> There is no padding between values (except for the last byte) which is padded with 0s.

Minor change.

### Jira

- [x] https://issues.apache.org/jira/browse/PARQUET-2362

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"
