### PR TITLE
MINOR: Fix INTERVAL sort order doc in parquet.thrift to be undefined

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -945,7 +945,7 @@ union ColumnOrder {
    *   TIME_MICROS - signed comparison
    *   TIMESTAMP_MILLIS - signed comparison
    *   TIMESTAMP_MICROS - signed comparison
-   *   INTERVAL - unsigned comparison
+   *   INTERVAL - undefined
    *   JSON - unsigned byte-wise comparison
    *   BSON - unsigned byte-wise comparison
    *   ENUM - unsigned byte-wise comparison


### PR DESCRIPTION
Fixing parquet.thrift doc of sort order for INTERVAL to reflect change made by https://github.com/apache/parquet-format/commit/c6d306daad4910d21927b8b4447dc6e9fae6c714

Figured this is trivial enough change to skip need for JIRA issue, but let me know if otherwise