### PR TITLE
PARQUET-2479: Update README with link to parquet website, clarify contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,17 @@
 
 # Parquet [![Build Status](https://github.com/apache/parquet-format/actions/workflows/test.yml/badge.svg)](https://github.com/apache/parquet-format/actions)
 
-Parquet is a columnar storage format that supports nested data.
+This repository contains the specification for [Apache Parquet] and
+[Apache Thrift] definitions to read and write Parquet metadata.
 
-Parquet metadata is encoded using Apache Thrift.
+Apache Parquet is an open source, column-oriented data file format
+designed for efficient data storage and retrieval. It provides high
+performance compression and encoding schemes to handle complex data in
+bulk and is supported in many programming language and analytics
+tools.
 
-The `Parquet-format` project contains all Thrift definitions that are necessary to create readers
-and writers for Parquet files.
+[Apache Parquet]: https://parquet.apache.org
+[Apache Thrift]: https://thrift.apache.org
 
 ## Motivation
 
@@ -176,7 +181,7 @@ following rules:
       * If the min is +0, the row group may contain -0 values as well.
       * If the max is -0, the row group may contain +0 values as well.
       * When looking for NaN values, min and max should be ignored.
-      
+
     * BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY - Lexicographic unsigned byte-wise
       comparison.
 


### PR DESCRIPTION

https://issues.apache.org/jira/browse/PARQUET-2479

As part of clarifying and improving the public communication about Parquet, I think we should also link parquet-format to the parquet.apache.org website

Also, the text in the format repo's readme is somewhat unclear on what is in the repo and how it related to other projects, so I clarified that as well

You can see the rendered version of the README here:
https://github.com/alamb/parquet-format/tree/alamb/doc_link_readme?tab=readme-ov-file#parquet-



### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2479
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation
This is a README only change
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
