### PR TITLE
PARQUET-2480: Clarify what "page index" means in Parquet.thrift

### DIFF
--- a/PageIndex.md
+++ b/PageIndex.md
@@ -19,9 +19,11 @@
 
 # ColumnIndex Layout to Support Page Skipping
 
-This document describes the format for column index pages in the Parquet
-footer. These pages contain statistics for DataPages and can be used to skip
-pages when scanning data in ordered and unordered columns.
+In Parquet, a "Page Index" is optional metadata for a
+Column Chunk, containing statistics for DataPages that can be used
+to skip pages when scanning in ordered and unordered columns.
+The page index is stored in one or more ColumnIndex structures,
+defined in [`parquet.thrift`](src/main/thrift/parquet.thrift)
 
 ## Problem Statement
 In previous versions of the format, Statistics are stored for ColumnChunks in

--- a/PageIndex.md
+++ b/PageIndex.md
@@ -19,10 +19,10 @@
 
 # ColumnIndex Layout to Support Page Skipping
 
-In Parquet, a "Page Index" is optional metadata for a
+In Parquet, a *page index* is optional metadata for a
 Column Chunk, containing statistics for DataPages that can be used
-to skip pages when scanning in ordered and unordered columns.
-The page index is stored in one or more ColumnIndex structures,
+to skip those pages when scanning in ordered and unordered columns.
+The page index is stored using the OffsetIndex and ColumnIndex structures,
 defined in [`parquet.thrift`](src/main/thrift/parquet.thrift)
 
 ## Problem Statement

--- a/PageIndex.md
+++ b/PageIndex.md
@@ -17,10 +17,10 @@
   - under the License.
   -->
 
-# ColumnIndex Layout to Support Page Skipping
+# Parquet page index: Layout to Support Page Skipping
 
 In Parquet, a *page index* is optional metadata for a
-Column Chunk, containing statistics for DataPages that can be used
+ColumnChunk, containing statistics for DataPages that can be used
 to skip those pages when scanning in ordered and unordered columns.
 The page index is stored using the OffsetIndex and ColumnIndex structures,
 defined in [`parquet.thrift`](src/main/thrift/parquet.thrift)

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1005,6 +1005,8 @@ struct PageLocation {
  * Optional offsets for each data page in a ColumnChunk.
  *
  * Forms part of the page index, along with ColumnIndex.
+ *
+ * OffsetIndex may be present even if ColumnIndex is not.
  */
 struct OffsetIndex {
   /**
@@ -1025,6 +1027,8 @@ struct OffsetIndex {
  * Optional statistics for each data page in a ColumnChunk.
  *
  * Forms part the page index, along with OffsetIndex.
+ *
+ * If this structure is present, OffsetIndex must also be present.
  *
  * For each field in this structure, <field>[i] refers to the page at
  * OffsetIndex.page_locations[i]

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1003,6 +1003,8 @@ struct PageLocation {
 
 /**
  * Optional offsets for each data page in a ColumnChunk.
+ *
+ * Forms part of the page index, along with OffsetIndex.
  */
 struct OffsetIndex {
   /**
@@ -1020,7 +1022,9 @@ struct OffsetIndex {
 }
 
 /**
- * "Page Index": Optional statistics for each data page in a ColumnChunk.
+ * Optional statistics for each data page in a ColumnChunk.
+ *
+ * Forms part the page index, along with OffsetIndex.
  *
  * For each field in this structure, <field>[i] refers to the page at
  * OffsetIndex.page_locations[i]

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -738,10 +738,10 @@ struct PageHeader {
 }
 
 /**
- * Wrapper struct to specify sort order
+ * Sort order within a RowGroup
  */
 struct SortingColumn {
-  /** The column index (in this row group) **/
+  /** The ordinal position of the column (in this row group) **/
   1: required i32 column_idx
 
   /** If true, indicates this column is sorted in descending order. **/
@@ -1001,6 +1001,9 @@ struct PageLocation {
   3: required i64 first_row_index
 }
 
+/**
+ * Optional offsets for each data page in a ColumnChunk.
+ */
 struct OffsetIndex {
   /**
    * PageLocations, ordered by increasing PageLocation.offset. It is required
@@ -1017,8 +1020,10 @@ struct OffsetIndex {
 }
 
 /**
- * Description for ColumnIndex.
- * Each <array-field>[i] refers to the page at OffsetIndex.page_locations[i]
+ * "Page Index": Optional statistics for each data page in a ColumnChunk.
+ *
+ * For each field in this structure, <field>[i] refers to the page at
+ * OffsetIndex.page_locations[i]
  */
 struct ColumnIndex {
   /**
@@ -1071,7 +1076,6 @@ struct ColumnIndex {
     * Same as repetition_level_histograms except for definitions levels.
     **/
    7: optional list<i64> definition_level_histograms;
-
 }
 
 struct AesGcmV1 {

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1004,7 +1004,7 @@ struct PageLocation {
 /**
  * Optional offsets for each data page in a ColumnChunk.
  *
- * Forms part of the page index, along with OffsetIndex.
+ * Forms part of the page index, along with ColumnIndex.
  */
 struct OffsetIndex {
   /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -738,7 +738,7 @@ struct PageHeader {
 }
 
 /**
- * Sort order within a RowGroup
+ * Sort order within a RowGroup of a leaf column
  */
 struct SortingColumn {
   /** The ordinal position of the column (in this row group) **/


### PR DESCRIPTION
https://issues.apache.org/jira/browse/PARQUET-2480

See the proposed update as rendered markdown: https://github.com/alamb/parquet-format/blob/alamb/page-index/PageIndex.md 

I have always found it very confusing that people refer to the term parquet "page index", for example [this message](https://lists.apache.org/thread/o9nxbmv1z4hph3v5s2z63jsklywpkyyj,)

However, the term "page index" is not used in the the [parquet.thrift](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift) file itself, but only appears as the name of the file that describes the `ColumnIndex` and `OffsetIndex`, [PageIndex.md](https://github.com/apache/parquet-format/blob/master/PageIndex.md)

This means I can't search for "page index" in the spec and find out what people are talking about

## Proposed Clarifications
1. Update the introductory paragraph of `PageIndex.md` to clarify use the term "page index" and explain that it is encoded as `ColumnIndex` and `OffsetIndex`
2. Update the description of `ColumnIndex` and `OffsetIndex` to include the term "page index" and clarify what those structures are used for.



### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2480
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation
This PR has no spec changes, only clarifications

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
