### PR TITLE
PARQUET-2482: Remove `<developers>` from the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,17 +71,6 @@
     </mailingList>
   </mailingLists>
 
-  <developers>
-    <developer>
-      <name>Julien Le Dem</name>
-      <email>julien@twitter.com</email>
-    </developer>
-    <developer>
-      <name>Nong Li</name>
-      <email>nong@cloudera.com</email>
-    </developer>
-  </developers>
-
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Apart from the original authors' great work, Apache projects should not mention any contributors in particular in the POM.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2482
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
