### PR TITLE
PARQUET-2488: Use term `row` consistently in `parquet.thrift`

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -181,10 +181,10 @@ enum ConvertedType {
  * Representation of Schemas
  */
 enum FieldRepetitionType {
-  /** This field is required (can not be null) and each record has exactly 1 value. */
+  /** This field is required (can not be null) and each row has exactly 1 value. */
   REQUIRED = 0;
 
-  /** The field is optional (can be null) and each record has 0 or 1 values. */
+  /** The field is optional (can be null) and each row has 0 or 1 values. */
   OPTIONAL = 1;
 
   /** The field is repeated and can contain 0 or more values */
@@ -581,9 +581,9 @@ struct DataPageHeader {
   /**
    * Number of values, including NULLs, in this data page.
    *
-   * If a OffsetIndex is present, a page must begin at a record
+   * If a OffsetIndex is present, a page must begin at a row
    * boundary (repetition_level = 0). Otherwise, pages may begin
-   * within a record (repetition_level > 0).
+   * within a row (repetition_level > 0).
    **/
   1: required i32 num_values
 
@@ -633,7 +633,7 @@ struct DataPageHeaderV2 {
   2: required i32 num_nulls
   /**
    * Number of rows in this data page. Every page must begin at a
-   * record boundary (repetition_level = 0): records must **not** be
+   * row boundary (repetition_level = 0): rows must **not** be
    * split across page boundaries when using V2 data pages.
    **/
   3: required i32 num_rows
@@ -1006,7 +1006,7 @@ struct PageLocation {
 
   /**
    * Index within the RowGroup of the first row of the page. When an
-   * OffsetIndex is present, pages must begin on record boundaries
+   * OffsetIndex is present, pages must begin on row boundaries
    * (repetition_level = 0).
    */
   3: required i64 first_row_index


### PR DESCRIPTION
As discussed on the mailing list ([thread link](https://lists.apache.org/thread/0gxjk4tphxls0gcrc7lt775pf8s7gtz3)) , parquet.thrift uses the terms `record` and `row` to mean the same thing, which could cause confusion

The consensus on the mailing list was to use the term "row".

This PR proposes changing `parquet.thrift` so it only uses the term 'row'


### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2488
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
