### PR TITLE
PARQUET-2139: Clarify ColumnChunk::file_offset is not used

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -867,7 +867,12 @@ struct ColumnChunk {
     **/
   1: optional string file_path
 
-  /** Byte offset in file_path to the ColumnMetaData **/
+  /** Byte offset in file_path to the ColumnMetaData.
+   Note: most writers include the ColumnMetadata inline (via meta_data).
+   While the presence of this field implies that ColumnMetaData can be
+   stored separately in the file, this is is not supported by many implementations
+   which assume meta_data is set.
+   **/
   2: required i64 file_offset
 
   /** Column metadata for this chunk. This is the same content as what is at


### PR DESCRIPTION
See also mailint list discussion: https://lists.apache.org/thread/r6r2cvzrdoorq6h6gqwh0b1hbfbhxv29

This field is not written correctly in the Java implementation and it not read in other implementations (like rust). Let's clarify this in the format docs

### Jira/GH
Related to https://github.com/apache/parquet-java/issues/2678

- [ ] My PR addresses https://issues.apache.org/jira/browse/PARQUET-2139

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

