### PR TITLE
PARQUET-2139: Deprecate ColumnChunk::file_offset field

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,29 +89,29 @@ more pages.
 This file and the [Thrift definition](src/main/thrift/parquet.thrift) should be read together to understand the format.
 
     4-byte magic number "PAR1"
-    <Column 1 Chunk 1 + Column Metadata>
-    <Column 2 Chunk 1 + Column Metadata>
+    <Column 1 Chunk 1 + Page Metadata>
+    <Column 2 Chunk 1 + Page Metadata>
     ...
-    <Column N Chunk 1 + Column Metadata>
-    <Column 1 Chunk 2 + Column Metadata>
-    <Column 2 Chunk 2 + Column Metadata>
+    <Column N Chunk 1 + Page Metadata>
+    <Column 1 Chunk 2 + Page Metadata>
+    <Column 2 Chunk 2 + Page Metadata>
     ...
-    <Column N Chunk 2 + Column Metadata>
+    <Column N Chunk 2 + Page Metadata>
     ...
-    <Column 1 Chunk M + Column Metadata>
-    <Column 2 Chunk M + Column Metadata>
+    <Column 1 Chunk M + Page Metadata>
+    <Column 2 Chunk M + Page Metadata>
     ...
-    <Column N Chunk M + Column Metadata>
+    <Column N Chunk M + Page Metadata>
     File Metadata
     4-byte length in bytes of file metadata (little endian)
     4-byte magic number "PAR1"
 
 In the above example, there are N columns in this table, split into M row
-groups.  The file metadata contains the locations of all the column metadata
+groups.  The file metadata contains the locations of all the column chunk
 start locations.  More details on what is contained in the metadata can be found
 in the Thrift definition.
 
-Metadata is written after the data to allow for single pass writing.
+File Metadata is written after the data to allow for single pass writing.
 
 Readers are expected to first read the file metadata to find all the column
 chunks they are interested in.  The columns chunks should then be read sequentially.
@@ -119,8 +119,8 @@ chunks they are interested in.  The columns chunks should then be read sequentia
  ![File Layout](https://raw.github.com/apache/parquet-format/master/doc/images/FileLayout.gif)
 
 ## Metadata
-There are three types of metadata: file metadata, column (chunk) metadata and page
-header metadata.  All thrift structures are serialized using the TCompactProtocol.
+There are two types of metadata: file metadata and page header metadata.  All thrift structures
+are serialized using the TCompactProtocol.
 
  ![Metadata diagram](https://github.com/apache/parquet-format/raw/master/doc/images/FileFormat.gif)
 

--- a/README.md
+++ b/README.md
@@ -89,19 +89,19 @@ more pages.
 This file and the [Thrift definition](src/main/thrift/parquet.thrift) should be read together to understand the format.
 
     4-byte magic number "PAR1"
-    <Column 1 Chunk 1 + Page Metadata>
-    <Column 2 Chunk 1 + Page Metadata>
+    <Column 1 Chunk 1>
+    <Column 2 Chunk 1>
     ...
-    <Column N Chunk 1 + Page Metadata>
-    <Column 1 Chunk 2 + Page Metadata>
-    <Column 2 Chunk 2 + Page Metadata>
+    <Column N Chunk 1>
+    <Column 1 Chunk 2>
+    <Column 2 Chunk 2>
     ...
-    <Column N Chunk 2 + Page Metadata>
+    <Column N Chunk 2>
     ...
-    <Column 1 Chunk M + Page Metadata>
-    <Column 2 Chunk M + Page Metadata>
+    <Column 1 Chunk M>
+    <Column 2 Chunk M>
     ...
-    <Column N Chunk M + Page Metadata>
+    <Column N Chunk M>
     File Metadata
     4-byte length in bytes of file metadata (little endian)
     4-byte magic number "PAR1"

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -867,12 +867,21 @@ struct ColumnChunk {
     **/
   1: optional string file_path
 
-  /** Byte offset in file_path to the ColumnMetaData **/
+  /** Deprecated: Byte offset in file_path to the ColumnMetaData
+   *
+   * Past use of this field has been inconsistent, with some implementations
+   * using it to point to the ColumnMetaData and some using it to point to
+   * the first page in the column chunk. In many cases, the ColumnMetaData at this
+   * location is wrong. This field is now deprecated and should not be used.
+   * Writers should set this field to 0 if no ColumnMetaData has been written outside
+   * the footer.
+   */
   2: required i64 file_offset
 
-  /** Column metadata for this chunk. This is the same content as what is at
-   * file_path/file_offset.  Having it here has it replicated in the file
-   * metadata.
+  /** Column metadata for this chunk. Some writers may also replicate this at the
+   * location pointed to by file_path/file_offset.
+   * Note: while marked as optional, this field is in fact required by most major
+   * Parquet implementations. As such, writers MUST populate this field.
    **/
   3: optional ColumnMetaData meta_data
 

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -876,7 +876,7 @@ struct ColumnChunk {
    * Writers should set this field to 0 if no ColumnMetaData has been written outside
    * the footer.
    */
-  2: required i64 file_offset
+  2: required i64 file_offset = 0
 
   /** Column metadata for this chunk. Some writers may also replicate this at the
    * location pointed to by file_path/file_offset.


### PR DESCRIPTION
An alternative to #439

Related to [parquet-java/#2678](https://github.com/apache/parquet-java/issues/2678) and https://github.com/apache/parquet-java/pull/1369

See mailing list discussion at https://lists.apache.org/thread/r6r2cvzrdoorq6h6gqwh0b1hbfbhxv29

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2139
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

