### PR TITLE
Clarify num-nulls handling in Statistics and ColumnIndex

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -263,7 +263,7 @@ struct Statistics {
     * Writers SHOULD always write this field even if it is zero (i.e. no null value)
     * or the column is not nullable.
     * Readers MUST distinguish between null_count not being present and null_count == 0.
-    * If null_count is not present, readers SHOULD NOT assume null_count == 0.
+    * If null_count is not present, readers MUST NOT assume null_count == 0.
     */
    3: optional i64 null_count;
    /** count of distinct values occurring */
@@ -1091,7 +1091,16 @@ struct ColumnIndex {
    */
   4: required BoundaryOrder boundary_order
 
-  /** A list containing the number of null values for each page **/
+  /**
+   * A list containing the number of null values for each page 
+   *
+   * Writers SHOULD always write this field even if no null value
+   * or the column is not nullable.
+   * Readers MUST distinguish between null_counts not being present 
+   * and null_count is 0.
+   * If null_counts is not present, readers MUST NOT assume all 
+   * null_count is 0.
+   */
   5: optional list<i64> null_counts
 
   /**

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -260,7 +260,7 @@ struct Statistics {
    /** 
     * count of null value in the column 
     *
-    * Writers should write this field even if it is zero or in non-null columns.
+    * Writers SHOULD always write this field even if it is zero (a.k.a. no null value)
     */
    3: optional i64 null_count;
    /** count of distinct values occurring */

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1094,8 +1094,8 @@ struct ColumnIndex {
   /**
    * A list containing the number of null values for each page 
    *
-   * Writers SHOULD always write this field even if no null value
-   * or the column is not nullable.
+   * Writers SHOULD always write this field even if no null values
+   * are present or the column is not nullable.
    * Readers MUST distinguish between null_counts not being present 
    * and null_count being 0.
    * If null_counts are not present, readers MUST NOT assume all 

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -257,7 +257,11 @@ struct Statistics {
     */
    1: optional binary max;
    2: optional binary min;
-   /** count of null value in the column */
+   /** 
+    * count of null value in the column 
+    *
+    * Writers should write this field even if it is zero or in non-null columns.
+    */
    3: optional i64 null_count;
    /** count of distinct values occurring */
    4: optional i64 distinct_count;

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -261,6 +261,9 @@ struct Statistics {
     * count of null value in the column 
     *
     * Writers SHOULD always write this field even if it is zero (a.k.a. no null value)
+    * or is an not nullable column.
+    * Readers SHOULD distinct null_count == 0 or not having null_count. If null_count
+    * doesn't exists, Readers cannot gurantees null_count == 0.
     */
    3: optional i64 null_count;
    /** count of distinct values occurring */

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1097,9 +1097,9 @@ struct ColumnIndex {
    * Writers SHOULD always write this field even if no null value
    * or the column is not nullable.
    * Readers MUST distinguish between null_counts not being present 
-   * and null_count is 0.
+   * and null_count being 0.
    * If null_counts is not present, readers MUST NOT assume all 
-   * null_count is 0.
+   * null counts are 0.
    */
   5: optional list<i64> null_counts
 

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -262,7 +262,7 @@ struct Statistics {
     *
     * Writers SHOULD always write this field even if it is zero (i.e. no null value)
     * or the column is not nullable.
-    * Readers SHOULD distinguish between null_count not being present and null_count == 0.
+    * Readers MUST distinguish between null_count not being present and null_count == 0.
     * If null_count is not present, readers SHOULD NOT assume null_count == 0.
     */
    3: optional i64 null_count;

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -258,12 +258,12 @@ struct Statistics {
    1: optional binary max;
    2: optional binary min;
    /** 
-    * count of null value in the column 
+    * Count of null values in the column.
     *
-    * Writers SHOULD always write this field even if it is zero (a.k.a. no null value)
-    * or is an not nullable column.
-    * Readers SHOULD distinct null_count == 0 or not having null_count. If null_count
-    * doesn't exists, Readers cannot gurantees null_count == 0.
+    * Writers SHOULD always write this field even if it is zero (i.e. no null value)
+    * or the column is not nullable.
+    * Readers SHOULD distinguish between null_count not being present and null_count == 0.
+    * If null_count is not present, readers SHOULD NOT assume null_count == 0.
     */
    3: optional i64 null_count;
    /** count of distinct values occurring */

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1098,7 +1098,7 @@ struct ColumnIndex {
    * or the column is not nullable.
    * Readers MUST distinguish between null_counts not being present 
    * and null_count being 0.
-   * If null_counts is not present, readers MUST NOT assume all 
+   * If null_counts are not present, readers MUST NOT assume all 
    * null counts are 0.
    */
   5: optional list<i64> null_counts


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Clarify num-nulls handling. I've mentioned this in maillist: https://lists.apache.org/thread/oqd9lt7p0jtf217hg0667xhk0zvwbgvt


### What changes are included in this PR?

Suggest writer to have num_nulls/null_count


### Do these changes have PoC implementations?

no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
