### PR TITLE
GH-452: Clarify use of RowGroup.ordinal field

### DIFF
--- a/Encryption.md
+++ b/Encryption.md
@@ -356,6 +356,11 @@ struct RowGroup {
 }
 ```
 
+The integrity of this field is protected by footer (FileMetaData) authenticated encryption. Therefore, 
+the reader implementations can use either a local row group counter (ordinal) or the `RowGroup.ordinal`
+field as an input to AAD suffix calculation. The latter option can be helpful when different reader 
+threads process different row groups in the same parquet file.
+
 A `crypto_metadata` field is set in each ColumnChunk in the encrypted columns. ColumnCryptoMetaData 
 is a union - the actual structure is chosen depending on whether the column is encrypted with the 
 footer encryption key, or with a column-specific key. For the latter, a key metadata can be specified.

--- a/Encryption.md
+++ b/Encryption.md
@@ -356,7 +356,7 @@ struct RowGroup {
 }
 ```
 
-The integrity of this field is protected by footer (FileMetaData) authenticated encryption. Therefore, 
+The integrity of this field is protected by authenticated encryption of the footer (FileMetaData). Therefore, 
 the reader implementations can use either a local row group counter (ordinal) or the `RowGroup.ordinal`
 field as an input to AAD suffix calculation. The latter option can be helpful when different reader 
 threads process different row groups in the same parquet file.


### PR DESCRIPTION
Encrypted files use three types of ordinals: row group, column, page. All three are simple local counters in both writers and readers. In addition, the row group ordinal is stored in the parquet footer (RowGroup.ordinal field). Parquet implementors can benefit from a clarification on the reason for and intended use of this field.