### PR TITLE
GH-465: Clarify backward-compatibility rules on LIST type

### DIFF
--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -681,7 +681,7 @@ optional group array_of_arrays (LIST) {
 
 #### Backward-compatibility rules
 
-Modern writers should always produce the 3-level LIST structure shown above.
+New writer implementations should always produce the 3-level LIST structure shown above.
 However, historically data files have been produced that use different structures
 to represent list-like data, and readers may include compatibility measures to
 interpret them as intended.

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -609,6 +609,17 @@ that is neither contained by a `LIST`- or `MAP`-annotated group nor annotated
 by `LIST` or `MAP` should be interpreted as a required list of required
 elements where the element type is the type of the field.
 
+```
+// List<Integer> (non-null list, non-null elements)
+repeated int32 num;
+
+// List<Tuple<Integer, String>> (non-null list, non-null elements)
+repeated group my_list {
+  required int32 num;
+  optional binary str (STRING);
+}
+```
+
 Implementations should use either `LIST` and `MAP` annotations _or_ unannotated
 repeated fields, but not both. When using the annotations, no unannotated
 repeated types are allowed.
@@ -755,29 +766,6 @@ optional group my_list (LIST) {
   repeated group foo {
     repeated int32 bar;
   };
-}
-```
-
-##### 1-level structure without `LIST` annotation
-
-Some existing data does not even have the `LIST` annotation and simply uses
-`repeated` repetition to annotate the element type. For backward-compatibility,
-both the list and elements are `required`.
-
-```
-// List<Integer> (non-null list, non-null elements)
-repeated int32 num;
-
-// Tuple<List<Integer>, List<String>> (non-null list, non-null elements)
-optional group my_list {
-  repeated int32 num;
-  repeated binary str (STRING);
-}
-
-// List<Tuple<Integer, String>> (non-null list, non-null elements)
-repeated group my_list {
-  required int32 num;
-  optional binary str (STRING);
 }
 ```
 

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -724,9 +724,8 @@ as 3-level structures:
    elements are required.
 2. If the repeated field is a group with multiple fields, then its type is the
    element type and elements are required.
-3. If the repeated field is a group with one field and the repetition of that
-   field is `repeated`, then its type is the element type and elements are
-   required.
+3. If the repeated field is a group with one field with `repeated` repetition,
+   then its type is the element type and elements are required.
 4. If the repeated field is a group with one field and is named either `array`
    or uses the `LIST`-annotated group's name with `_tuple` appended then the
    repeated type is the element type and elements are required.

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -609,17 +609,6 @@ that is neither contained by a `LIST`- or `MAP`-annotated group nor annotated
 by `LIST` or `MAP` should be interpreted as a required list of required
 elements where the element type is the type of the field.
 
-```
-// List<Integer> (non-null list, non-null elements)
-repeated int32 num;
-
-// List<Tuple<Integer, String>> (non-null list, non-null elements)
-repeated group my_list {
-  required int32 num;
-  optional binary str (STRING);
-}
-```
-
 For all fields in the schema, implementations should use either `LIST` and
 `MAP` annotations _or_ unannotated repeated fields, but not both. When using
 the annotations, no unannotated repeated types are allowed.
@@ -686,8 +675,6 @@ above. However, historically data files have been produced that use different
 structures to represent list-like data, and readers may include compatibility
 measures to interpret them as intended.
 
-##### 3-level structure with different field names
-
 It is required that the repeated group of elements is named `list` and that
 its element field is named `element`. However, these names may not be used in
 existing data and should not be enforced as errors when reading. For example,
@@ -702,23 +689,14 @@ optional group my_list (LIST) {
 }
 ```
 
-##### 2-level structure
-
 Some existing data does not include the inner element layer, resulting in a
 `LIST` that annotates a 2-level structure. Unlike the 3-level structure, the
 repetition of a 2-level structure can be `optional`, `required`, or `repeated`.
 When it is `repeated`, the `LIST`-annotated 2-level structure can only serve as
 an element within another `LIST`-annotated 2-level structure.
 
-```
-<list-repetition> group <name> (LIST) {
-  repeated <element-type> <element-name>;
-}
-```
-
 For backward-compatibility, the type of elements in `LIST`-annotated structures
-should always be determined by the following rules if they cannot be determined
-as 3-level structures:
+should always be determined by the following rules:
 
 1. If the repeated field is not a group, then its type is the element type and
    elements are required.

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -681,10 +681,10 @@ optional group array_of_arrays (LIST) {
 
 #### Backward-compatibility rules
 
-New writer implementations should always produce the 3-level LIST structure shown above.
-However, historically data files have been produced that use different structures
-to represent list-like data, and readers may include compatibility measures to
-interpret them as intended.
+New writer implementations should always produce the 3-level LIST structure shown
+above. However, historically data files have been produced that use different
+structures to represent list-like data, and readers may include compatibility
+measures to interpret them as intended.
 
 ##### 3-level structure with different field names
 

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -609,6 +609,20 @@ that is neither contained by a `LIST`- or `MAP`-annotated group nor annotated
 by `LIST` or `MAP` should be interpreted as a required list of required
 elements where the element type is the type of the field.
 
+```
+WARNING: writers should not produce list types like these examples! They are
+just for the purpose of reading existing data for backward-compatibility.
+
+// List<Integer> (non-null list, non-null elements)
+repeated int32 num;
+
+// List<Tuple<Integer, String>> (non-null list, non-null elements)
+repeated group my_list {
+  required int32 num;
+  optional binary str (STRING);
+}
+```
+
 For all fields in the schema, implementations should use either `LIST` and
 `MAP` annotations _or_ unannotated repeated fields, but not both. When using
 the annotations, no unannotated repeated types are allowed.
@@ -713,6 +727,9 @@ should always be determined by the following rules:
 Examples that can be interpreted using these rules:
 
 ```
+WARNING: writers should not produce list types like these examples! They are
+just for the purpose of reading existing data for backward-compatibility.
+
 // Rule 1: List<Integer> (nullable list, non-null elements)
 optional group my_list (LIST) {
   repeated int32 element;

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -691,10 +691,14 @@ should always be determined by the following rules:
 1. If the repeated field is not a group, then its type is the element type and
    elements are required.
 2. If the repeated field is a group with multiple fields, then its type is the
-   element type and elements are required.
-3. If the repeated field is a group with one field and is named either `array`
-   or uses the `LIST`-annotated group's name with `_tuple` appended then the
-   repeated type is the element type and elements are required.
+   element type and elements are required. To be clear, if the group does not
+   have annotation, the element type resolves to a multi-field Tuple. If the
+   group is `LIST`-annotated or `MAP`-annotated, it should resolve to List or
+   Map type, respectively.
+3. If the repeated field is a group (without annotation) with one `required` or
+   `optional` field, and is named either `array` or uses the `LIST`-annotated
+   group's name with `_tuple` appended, then the repeated type (a single-field
+   Tuple type) is the element type and elements are required.
 4. Otherwise, the repeated field's type is the element type with the repeated
    field's repetition.
 
@@ -726,6 +730,14 @@ optional group my_list (LIST) {
   repeated group my_list_tuple {
     required binary str (STRING);
   };
+}
+
+// List<List<Integer>> (outer list is nullable with non-null elements,
+// inner list is non-null with non-null elements)
+optional group my_list (LIST) {
+  repeated group array (LIST) {
+    repeated int32 array;
+  }
 }
 ```
 

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -681,6 +681,11 @@ optional group array_of_arrays (LIST) {
 
 #### Backward-compatibility rules
 
+Modern writers should always produce the 3-level LIST structure shown above.
+However, historically data files have been produced that use different structures to
+represent list-like data, and readers may include compatibility measures to interpret
+them as intended.
+
 ##### 3-level structure with different field names
 
 It is required that the repeated group of elements is named `list` and that

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -767,8 +767,8 @@ optional group my_list (LIST) {
 ##### 1-level structure without `LIST` annotation
 
 Some existing data does not even have the `LIST` annotation and simply uses
-`repeated` repetition to annotate the element type. In this case, the element
-type MUST be a primitive type and both the list and elements are required.
+`repeated` repetition to annotate the element type. In this case both the list
+and elements are required.
 
 ```
 // List<Integer> (non-null list, non-null elements)

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -763,6 +763,13 @@ optional group my_list (LIST) {
     required binary str (STRING);
   };
 }
+
+// Rule 5: List<String>  (nullable list, nullable elements)
+optional group my_list (LIST) {
+  repeated group element {
+    optional binary str (STRING);
+  };
+}
 ```
 
 ### Maps

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -682,9 +682,9 @@ optional group array_of_arrays (LIST) {
 #### Backward-compatibility rules
 
 Modern writers should always produce the 3-level LIST structure shown above.
-However, historically data files have been produced that use different structures to
-represent list-like data, and readers may include compatibility measures to interpret
-them as intended.
+However, historically data files have been produced that use different structures
+to represent list-like data, and readers may include compatibility measures to
+interpret them as intended.
 
 ##### 3-level structure with different field names
 
@@ -704,9 +704,11 @@ optional group my_list (LIST) {
 
 ##### 2-level structure
 
-Some existing data does not include the inner element layer, meaning that `LIST`
-annotates a 2-level structure. In contrast to 3-level structure, the repetition
-of 2-level structure can be `optional`, `required`, or `repeated`.
+Some existing data does not include the inner element layer, resulting in a
+`LIST` that annotates a 2-level structure. Unlike the 3-level structure, the
+repetition of a 2-level structure can be `optional`, `required`, or `repeated`.
+When it is `repeated`, the `LIST`-annotated 2-level structure can only serve as
+an element within another `LIST`-annotated 2-level structure.
 
 ```
 <list-repetition> group <name> (LIST) {
@@ -714,15 +716,17 @@ of 2-level structure can be `optional`, `required`, or `repeated`.
 }
 ```
 
-For backward-compatibility, the type of elements in `LIST`-annotated 2-level
-structures should always be determined by the following rules:
+For backward-compatibility, the type of elements in `LIST`-annotated structures
+should always be determined by the following rules if they cannot be determined
+as 3-level structures:
 
 1. If the repeated field is not a group, then its type is the element type and
    elements are required.
 2. If the repeated field is a group with multiple fields, then its type is the
    element type and elements are required.
-3. If the repeated field is a group with a `repeated` field, then the repeated
-   field is the element type because the type cannot be a 3-level list.
+3. If the repeated field is a group with one field and the repetition of that
+   field is `repeated`, then its type is the element type and elements are
+   required.
 4. If the repeated field is a group with one field and is named either `array`
    or uses the `LIST`-annotated group's name with `_tuple` appended then the
    repeated type is the element type and elements are required.

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -753,7 +753,14 @@ optional group my_list (LIST) {
 optional group my_list (LIST) {
   repeated group array (LIST) {
     repeated int32 array;
-  }
+  };
+}
+
+// Rule 5: List<Struct<List<Integer>>> (nullable outer list with non-null elements)
+optional group my_list (LIST) {
+  repeated group foo {
+    repeated int32 bar;
+  };
 }
 ```
 
@@ -767,10 +774,16 @@ type MUST be a primitive type and both the list and elements are required.
 // List<Integer> (non-null list, non-null elements)
 repeated int32 num;
 
-// Struct<List<Integer>, List<String>> (non-null list, non-null elements)
+// Struct<List<Integer>,List<String>> (non-null list, non-null elements)
 optional group whatever {
   repeated int32 num;
   repeated binary str (STRING);
+}
+
+// List<Struct<Integer,String>> (non-null list, non-null elements)
+repeated group whatever {
+  required int32 num;
+  optional binary str (STRING);
 }
 ```
 

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -691,14 +691,12 @@ should always be determined by the following rules:
 1. If the repeated field is not a group, then its type is the element type and
    elements are required.
 2. If the repeated field is a group with multiple fields, then its type is the
-   element type and elements are required. To be clear, if the group does not
-   have annotation, the element type resolves to a multi-field Tuple. If the
-   group is `LIST`-annotated or `MAP`-annotated, it should resolve to List or
-   Map type, respectively.
+   element type and elements are required. In this case, the element type is
+   a Struct type with multiple fields.
 3. If the repeated field is a group (without annotation) with one `required` or
    `optional` field, and is named either `array` or uses the `LIST`-annotated
    group's name with `_tuple` appended, then the repeated type (a single-field
-   Tuple type) is the element type and elements are required.
+   Struct type) is the element type and elements are required.
 4. Otherwise, the repeated field's type is the element type with the repeated
    field's repetition.
 
@@ -710,7 +708,7 @@ optional group my_list (LIST) {
   repeated int32 element;
 }
 
-// List<Tuple<String, Integer>> (nullable list, non-null elements)
+// List<Struct<String, Integer>> (nullable list, non-null elements)
 optional group my_list (LIST) {
   repeated group element {
     required binary str (STRING);
@@ -718,14 +716,14 @@ optional group my_list (LIST) {
   };
 }
 
-// List<OneTuple<String>> (nullable list, non-null elements)
+// List<Struct<String>> (nullable list, non-null elements)
 optional group my_list (LIST) {
   repeated group array {
     required binary str (STRING);
   };
 }
 
-// List<OneTuple<String>> (nullable list, non-null elements)
+// List<Struct<String>> (nullable list, non-null elements)
 optional group my_list (LIST) {
   repeated group my_list_tuple {
     required binary str (STRING);

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -684,25 +684,23 @@ optional group my_list (LIST) {
 }
 ```
 
-Some existing data does not include the inner element layer, meaning that
-`LIST` annotates a 2-level structure. In contrast to 3-level structure, the
-repetition of the outer level `LIST`-annotated 2-level structure can be
-`optional`, `required`, or `required`. For backward-compatibility, the type of
-elements in `LIST`-annotated structures should always be determined by the
-following rules:
+Some existing data does not include the inner element layer, meaning that `LIST`
+annotates a 2-level structure. In contrast to 3-level structure, the repetition
+of the outer level of 2-level structure can be `optional`, `required`, or
+`repeated`. For backward-compatibility, the type of elements in `LIST`-annotated
+2-level structures should always be determined by the following rules:
 
 1. If the repeated field is not a group, then its type is the element type and
-   elements are required. In this case, `LIST` annotates a 2-level structure.
-2. If the repeated field is a group with multiple fields, then its type is the
-   element type and elements are required. In this case, `LIST` annotates a
-   2-level structure and the element type is a Struct type with multiple fields.
+   elements are required.
+2. If the repeated field is a group with multiple fields, then its type (Struct
+   type with multiple fields) is the element type and elements are required.
 3. If the repeated field is a group (not `LIST`-annotated) with one `required`
    or `optional` field, and is named either `array` or uses the `LIST`-annotated
-   group's name with `_tuple` appended, then the repeated type (a single-field
-   Struct type) is the element type and elements are required.
+   group's name with `_tuple` appended, then the repeated type (Struct type with
+   single field) is the element type and elements are required.
 4. Otherwise, the repeated field's type is the element type with the repeated
-   field's repetition. In this case, `LIST` annotates a 2-level structure. Note
-   that the repeated field cannot be a 3-level LIST, as such a LIST's repetition
+   field's repetition. Note that the repeated field cannot be `LIST`-annotated
+   or `MAP`-annotated group with 3-level structure, as such a group's repetition
    must be `required` or `optional`.
 
 Examples that can be interpreted using these rules:
@@ -743,15 +741,6 @@ optional group my_list (LIST) {
     repeated int32 array;
   }
 }
-```
-
-Some existing data does not even have the `LIST` annotation and simply uses
-`repeated` repetition to annotate the element type. In this case, the element
-type can be either a primitive type or a `LIST`-annotated 2-level group. 
-
-```
-// List<Integer> (non-null list, non-null elements)
-repeated int32 num;
 ```
 
 ### Maps

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -685,7 +685,7 @@ optional group my_list (LIST) {
 ```
 
 Some existing data does not include the inner element layer, meaning that
-`LIST` annotates a 2-level structure. In contrast to 3-level structure, The
+`LIST` annotates a 2-level structure. In contrast to 3-level structure, the
 repetition of the outer level `LIST`-annotated 2-level structure can be
 `optional`, `required`, or `required`. For backward-compatibility, the type of
 elements in `LIST`-annotated structures should always be determined by the
@@ -699,12 +699,11 @@ following rules:
 3. If the repeated field is a group (not `LIST`-annotated) with one `required`
    or `optional` field, and is named either `array` or uses the `LIST`-annotated
    group's name with `_tuple` appended, then the repeated type (a single-field
-   Struct type) is the element type and elements are required. This is a special
-   case of 3-level structure where the names are respected.
+   Struct type) is the element type and elements are required.
 4. Otherwise, the repeated field's type is the element type with the repeated
    field's repetition. In this case, `LIST` annotates a 2-level structure. Note
-   that the repeated field cannot be a 3-level LIST whose repetition must be
-   `required` or `optional`.
+   that the repeated field cannot be a 3-level LIST, as such a LIST's repetition
+   must be `required` or `optional`.
 
 Examples that can be interpreted using these rules:
 
@@ -744,6 +743,15 @@ optional group my_list (LIST) {
     repeated int32 array;
   }
 }
+```
+
+Some existing data does not even have the `LIST` annotation and simply uses
+`repeated` repetition to annotate the element type. In this case, the element
+type can be either a primitive type or a `LIST`-annotated 2-level group. 
+
+```
+// List<Integer> (non-null list, non-null elements)
+repeated int32 num;
 ```
 
 ### Maps

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -620,9 +620,9 @@ repeated group my_list {
 }
 ```
 
-Implementations should use either `LIST` and `MAP` annotations _or_ unannotated
-repeated fields, but not both. When using the annotations, no unannotated
-repeated types are allowed.
+For all fields in the schema, implementations should use either `LIST` and
+`MAP` annotations _or_ unannotated repeated fields, but not both. When using
+the annotations, no unannotated repeated types are allowed.
 
 ### Lists
 
@@ -763,13 +763,6 @@ optional group my_list (LIST) {
 optional group my_list (LIST) {
   repeated group my_list_tuple {
     required binary str (STRING);
-  };
-}
-
-// Rule 5: List<OneTuple<List<Integer>>> (nullable outer list, non-null elements)
-optional group my_list (LIST) {
-  repeated group foo {
-    repeated int32 bar;
   };
 }
 ```


### PR DESCRIPTION
### Rationale for this change

The C++ reader of parquet-cpp is having a hard time to read Parquet file written by parquet-java with `parquet.avro.write-old-list-structure=true` and schema below:
```
optional group a (LIST) {
  repeated group array (LIST) {
    repeated int32 array;
  }
}
```

See https://github.com/apache/arrow/issues/43994 and https://github.com/apache/arrow/pull/43995

### What changes are included in this PR?

Clarify the rules for various list types.

1. Unannotated repeated fields.

```
repeated int32 num_list;

repeated group my_list {
  required int32 num;
  optional binary str (STRING);
}
```

2. LIST-annotated 2-level structures.

```
<list-repetition> group <name> (LIST) {
  repeated <element-type> <element-name>;
}

list-repetition: can be repeated, required, and optional.
```

### Do these changes have PoC implementations?

Not required

Closes #465
