### PR TITLE
MINOR: typo: LogicalTypes.md -- s/is used to for/is used for/

### DIFF
--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -260,7 +260,7 @@ The sort order for `FLOAT16` is signed (with special handling of NANs and signed
 
 ### DATE
 
-`DATE` is used to for a logical date type, without a time of day. It must
+`DATE` is used for a logical date type, without a time of day. It must
 annotate an `int32` that stores the number of days from the Unix epoch, 1
 January 1970.
 


### PR DESCRIPTION
### Rationale for this change

Typo in documentation

### What changes are included in this PR?

typo: LogicalTypes.md -- s/is used to for/is used for/

### Do these changes have PoC implementations?

No
