### PR TITLE
Add fixed(L) type to variant spec

### DIFF
--- a/VariantEncoding.md
+++ b/VariantEncoding.md
@@ -399,6 +399,8 @@ The Decimal type contains a scale, but no precision. The implied precision of a 
 | Timestamp            | timestamp with time zone   | `22`    | TIMESTAMP(isAdjustedToUTC=true, NANOS)       | 8-byte little-endian                                                                        |
 | TimestampNTZ         | timestamp without time zone | `23`    | TIMESTAMP(isAdjustedToUTC=false, NANOS)      | 8-byte little-endian                                                                        |
 | UUID                 | uuid                        | `24`    | UUID                         | 16-byte big-endian                                                                         |
+| Fixed             | Byte array with 1-byte length L | `25`    | FIXED_LEN_BYTE_ARRAY[L]     |  1 byte little-endian size L, followed by length-L bytes    |
+| Fixed             | Byte array with 4-byte length L | `26`    | FIXED_LEN_BYTE_ARRAY[L]     |  4 byte little-endian size L, followed by length-L bytes    |
 
 The *Type Equivalence Class* column indicates logical equivalence of physically encoded types.
 For example, a user expression operating on a string value containing "hello" should behave the same, whether it is encoded with the short string optimization, or long string encoding.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change


### What changes are included in this PR?
fixed(L) type is not added for variant. 
Update the spec to add the presentation for fixed(L): the type is fixed and the value includes the length and byte array.

### Do these changes have PoC implementations?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #480