### PR TITLE
MINOR: Add links to projects on README and update parquet-compatibility to parquet-testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ Parquet is built to be used by anyone. The Hadoop ecosystem is rich with data pr
 
 ## Modules
 
-The `parquet-format` project contains format specifications and Thrift definitions of metadata required to properly read Parquet files.
+The [parquet-format] project contains format specifications and Thrift definitions of metadata required to properly read Parquet files.
 
-The `parquet-java` project contains multiple sub-modules, which implement the core components of reading and writing a nested, column-oriented data stream, map this core onto the parquet format, and provide Hadoop Input/Output Formats, Pig loaders, and other java-based utilities for interacting with Parquet.
+The [parquet-java] project contains multiple sub-modules, which implement the core components of reading and writing a nested, column-oriented data stream, map this core onto the parquet format, and provide Hadoop Input/Output Formats, Pig loaders, and other java-based utilities for interacting with Parquet.
 
-The `parquet-compatibility` project contains compatibility tests that can be used to verify that implementations in different languages can read and write each other's files.
+The [parquet-testing] project contains compatibility tests that can be used to verify that implementations in different languages can read and write each other's files.
+
+[parquet-format]: https://github.com/apache/parquet-format
+[parquet-java]: https://github.com/apache/parquet-java
+[parquet-testing]: https://github.com/apache/parquet-testing
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The [parquet-format] project contains format specifications and Thrift definitio
 
 The [parquet-java] project contains multiple sub-modules, which implement the core components of reading and writing a nested, column-oriented data stream, map this core onto the parquet format, and provide Hadoop Input/Output Formats, Pig loaders, and other java-based utilities for interacting with Parquet.
 
-The [parquet-testing] project contains compatibility tests that can be used to verify that implementations in different languages can read and write each other's files.
+The [parquet-testing] project contains a set of files that can be used to verify that implementations in different languages can read and write each other's files.
 
 [parquet-format]: https://github.com/apache/parquet-format
 [parquet-java]: https://github.com/apache/parquet-java
@@ -298,10 +298,6 @@ There are many places in the format for compatible extensions:
 
 Parquet Thrift IDL reserves field-id `32767` of every Thrift struct for extensions.
 The (Thrift) type of this field is always `binary`.
-
-## Testing
-
-The [apache/parquet-testing](https://github.com/apache/parquet-testing) contains a set of Parquet files for testing purposes.
 
 ## Contributing
 Comment on the issue and/or contact [the parquet-dev mailing list](http://mail-archives.apache.org/mod_mbox/parquet-dev/) with your questions and ideas.


### PR DESCRIPTION
### Rationale for this change

While reading the README file I found that `parquet-compatibility` seems to be a wrong component and should be `parquet-testing`.
I also think adding links can help navigation for users interested while reading the README file.

### What changes are included in this PR?

- Update from `parquet-compatibility` to `parquet-testing`
- Add links to different projects

### Do these changes have PoC implementations?

Not required
