### PR TITLE
MINOR: Replace homogenous with homogeneous

### DIFF
--- a/VariantShredding.md
+++ b/VariantShredding.md
@@ -24,7 +24,7 @@
 
 The Variant type is designed to store and process semi-structured data efficiently, even with heterogeneous values.
 Query engines encode each Variant value in a self-describing format, and store it as a group containing `value` and `metadata` binary fields in Parquet.
-Since data is often partially homogenous, it can be beneficial to extract certain fields into separate Parquet columns to further improve performance.
+Since data is often partially homogeneous, it can be beneficial to extract certain fields into separate Parquet columns to further improve performance.
 This process is **shredding**.
 
 Shredding enables the use of Parquet's columnar representation for more compact data encoding, column statistics for data skipping, and partial projections.


### PR DESCRIPTION
### Rationale for this change
I believe _homogeneous_ is the correct word to describe data that shares a common type or characteristic and _homogenous_ is a common misspelling.  

Other sources use this spelling
https://docs.aws.amazon.com/whitepapers/latest/aws-cloud-data-ingestion-patterns-practices/homogeneous-data-ingestion-patterns.html 
https://www.dremio.com/wiki/homogeneous-data/