### PR TITLE
GH-493: Clarify Bounding Box Behavior in GeospatialStatistics 

### DIFF
--- a/Geospatial.md
+++ b/Geospatial.md
@@ -204,10 +204,12 @@ considered valid values under this specification. While different WKB
 readers may interpret such values differently, the resulting output should 
 be treated as invalid.
 
-* `NaN`: Not a Number. For example, `POINT EMPTY` in WKB is represented by a 
-  `Point` with each ordinate value set to an IEEE-754 quiet NaN value.
+* `NaN`: Not a Number. For example, a `Point` with no X and Y values in WKB is 
+  represented by a `Point` with each ordinate value set to an IEEE-754 quiet 
+  NaN value (hex: `01 01 00 00 00 00 00 00 00 00 00 00 f8 7f 00 00 00 00 00 00 f8 7f`).
 * `Empty geometries`: Geometries explicitly marked as empty in WKB using 
   indicators such as `numPoints`, `numRings`, or `numGeometries`. Examples 
-  include `LINESTRING EMPTY` or `POLYGON EMPTY`.
+  include `LineString` with no coordinates (hex: `01 02 00 00 00 00 00 00 
+  00`) or `Polygon` with no coordinates (hex: `01 03 00 00 00 00 00 00 00`).
 * `Out-of-bounds coordinates`: Values that fall outside the valid range 
   for `GEOGRAPHY` types. For example, `x < -180` or `x > 180`.

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -104,6 +104,19 @@ crosses the antimeridian line. In geographic terminology, the concepts of `xmin`
 For `GEOGRAPHY` types, X and Y values are restricted to the canonical ranges of
 [-180, 180] for X and [-90, 90] for Y.
 
+When `GeospatialStatistics` is present, writers must omit zmin and zmax if and
+only if there are zero non-NaN Z values in the column chunk, and must omit mmin
+and mmax if and only if there are zero non-NaN M values. The bounding box must 
+be omitted entirely if and only if there are zero non-NaN X values or zero 
+non-NaN Y values in the column chunk. If Z or M values are missing, the writer
+may still include a bounding box using only the available dimensions.
+
+Readers may interpret the absence of a bounding box, zmin/zmax, or mmin/mmax as
+an indication that all corresponding values are null, and may use this 
+information to skip data during predicate evaluation. For example, a reader may
+skip a row group if the bounding box is absent, indicating that all X and Y 
+coordinates are null.
+
 ```thrift
 struct BoundingBox {
   1: required double xmin;

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -120,12 +120,14 @@ Readers should follow the guidelines below when examining bounding boxes.
     * X and Y: Both X and Y of the bounding box must be present. If any of 
       `xmin`, `ymin`, `xmax`, or `ymax` is `NaN`, the bounding box is not 
       reliable and should not be used.
-    * Z: If Z of the bounding box is missing, readers should not assume 
-      anything about the presence or validity of Z values and may need to 
-      load individual coordinates for validation.
-    * M: If M of the bounding box is missing, readers should not assume
-      anything about the presence or validity of M values and may need to 
-      load individual coordinates for validation.
+    * Z: If Z of the bounding box is missing or either `zmin` or `zmax` is 
+      `NaN`, readers should not assume anything about the presence or 
+      validity of Z values and may need to load individual coordinates for 
+      validation.
+    * M: If M of the bounding box is missing or either `mmin` or `mmax` is 
+      `NaN`, readers should not assume anything about the presence or 
+      validity of M values and may need to load individual coordinates for 
+      validation.
 
 For the X values only, xmin may be greater than xmax. In this case, an object
 in this bounding box may match if it contains an X such that `x >= xmin` OR

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -85,10 +85,9 @@ associated with each point.
 The Z values introduce the third dimension coordinate. Usually they are used to
 indicate the height, or elevation.
 
-M values are an opportunity for a geospatial instance to express a fourth
-dimension as an axis value. These values can be used as a linear reference
-value (e.g., highway milepost value), a timestamp, or some other value as defined
-by the CRS.
+M values are an opportunity for a geospatial instance to track a value in a 
+fourth dimension. These values can be used as a linear reference value (e.g., 
+highway milepost value), a timestamp, or some other value as defined by the CRS.
 
 Bounding box is defined as the thrift struct below in the representation of
 min/max value pair of coordinates from each axis. Note that X and Y Values are
@@ -200,15 +199,15 @@ ordering explicitly overrides the axis order as specified in the CRS.
 
 # Special geospatial values
 
-A special geospatial value refers to an individual axis value (e.g., X, Y, Z,
+A special geospatial value refers to an individual scalar value (e.g., X, Y, Z,
 or M) within a coordinate of a non-`null` geospatial instance. These special 
 values are excluded from bounding box calculations. For example, in a 
 `LineString` instance with XY coordinates `[(1, 2), (NaN, 3), (4, 5)]`, the 
 `NaN` value on the X axis will be excluded from the bounding box calculation, 
-while all other axis values will be included.
+while all other scalar values will be included.
 
 * `NaN`: Not a Number. A `Point` with no X and Y values in WKB is 
-  represented by a `Point` with each axis value set to an IEEE-754 
+  represented by a `Point` with each scalar value set to an IEEE-754 
   NaN value (e.g., hex: `01 01 00 00 00 00 00 00 00 00 00 00 f8 7f 00 00 00 00 00 00 f8 7f`).
   NaN values in other geometry types are typically considered invalid 
   geometries by other libraries.

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -203,7 +203,7 @@ non-`null` geospatial instance that should be excluded from bounding box
 calculations.
 
 * `NaN`: Not a Number. A `Point` with no X and Y values in WKB is 
-  represented by a `Point` with each ordinate value set to an IEEE-754 
+  represented by a `Point` with each coordinate value set to an IEEE-754 
   NaN value (e.g., hex: `01 01 00 00 00 00 00 00 00 00 00 00 f8 7f 00 00 00 00 00 00 f8 7f`).
   NaN values in other geometry types are typically considered invalid 
   geometries by other libraries.

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -99,7 +99,7 @@ the presence of invalid values. An invalid geospatial value refers to any of
 the following: `NaN`, `null`, `does not exist` (e.g., LINESTRING EMPTY), or 
 `out of bounds` (e.g., `x < -180` or `x > 180` for `GEOGRAPHY` types):
 
-* X and Y: Skip any invalid X or Y value and processing the remaining X or Y 
+* X and Y: Skip any invalid X or Y value and continue processing the remaining X or Y 
   values. Do not produce a bounding box if all X or all Y values are invalid.
 
 * Z: Skip any invalid Z value and continue processing the remaining Z values.

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -104,7 +104,7 @@ crosses the antimeridian line. In geographic terminology, the concepts of `xmin`
 For `GEOGRAPHY` types, X and Y values are restricted to the canonical ranges of
 [-180, 180] for X and [-90, 90] for Y.
 
-When `GeospatialStatistics` is present, writers must omit zmin and zmax if and
+To produce `GeospatialStatistics`, writers must omit zmin and zmax if and
 only if there are zero non-NaN Z values in the column chunk, and must omit mmin
 and mmax if and only if there are zero non-NaN M values. The bounding box must 
 be omitted entirely if and only if there are zero non-NaN X values or zero 

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -86,7 +86,7 @@ The Z values introduce the third dimension coordinate. Usually they are used to
 indicate the height, or elevation.
 
 M values are an opportunity for a geospatial instance to express a fourth
-dimension as a coordinate value. These values can be used as a linear reference
+dimension as an axis value. These values can be used as a linear reference
 value (e.g., highway milepost value), a timestamp, or some other value as defined
 by the CRS.
 
@@ -113,7 +113,7 @@ the presence of edge cases.
 Readers should follow the guidelines below when examining bounding boxes.
 
 * No bounding box: No assumptions can be made about the presence or validity 
-  of coordinate values. Readers may need to load all individual coordinate 
+  of geospatial values. Readers may need to load all individual coordinate 
   values for validation.
 
 * A bounding box is present:
@@ -200,12 +200,15 @@ ordering explicitly overrides the axis order as specified in the CRS.
 
 # Special geospatial values
 
-A special geospatial value refers to the coordinate values of a 
-non-`null` geospatial instance that should be excluded from bounding box 
-calculations.
+A special geospatial value refers to an individual axis value (e.g., X, Y, Z,
+or M) within a coordinate of a non-`null` geospatial instance. These special 
+values are excluded from bounding box calculations. For example, in a 
+`LineString` instance with XY coordinates `[(1, 2), (NaN, 3), (4, 5)]`, the 
+`NaN` value on the X axis will be excluded from the bounding box calculation, 
+while all other axis values will be included.
 
 * `NaN`: Not a Number. A `Point` with no X and Y values in WKB is 
-  represented by a `Point` with each coordinate value set to an IEEE-754 
+  represented by a `Point` with each axis value set to an IEEE-754 
   NaN value (e.g., hex: `01 01 00 00 00 00 00 00 00 00 00 00 f8 7f 00 00 00 00 00 00 f8 7f`).
   NaN values in other geometry types are typically considered invalid 
   geometries by other libraries.

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -205,8 +205,10 @@ readers may interpret such values differently, the resulting output should
 be treated as invalid.
 
 * `NaN`: Not a Number. For example, a `Point` with no X and Y values in WKB is 
-  represented by a `Point` with each ordinate value set to an IEEE-754 quiet 
-  NaN value (hex: `01 01 00 00 00 00 00 00 00 00 00 00 f8 7f 00 00 00 00 00 00 f8 7f`).
+  represented by a `Point` with each ordinate value set to an IEEE-754 
+  NaN value (e.g., hex: `01 01 00 00 00 00 00 00 00 00 00 00 f8 7f 00 00 00 00 00 00 f8 7f`).
+  NaN values in other geometry types are typically considered invalid geometries by other
+  libraries.
 * `Empty geometries`: Geometries explicitly marked as empty in WKB using 
   indicators such as `numPoints`, `numRings`, or `numGeometries`. Examples 
   include `LineString` with no coordinates (hex: `01 02 00 00 00 00 00 00 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Update the specification to offer clearer instructions on how writers should populate bounding box values in the presence of NaNs, and how readers should interpret missing or incomplete bounding boxes.

### What changes are included in this PR?

Added comments in the `Bounding Box` section of the `Geospatial.md`.

Below is an example illustrating how bounding box statistics behave based on the presence of X and Y values:

All values in this example file are allowed by WKB encoding.


```
--- Parquet file

file-level bbox: [1, 9, 100, 900]

-- Row group 1
row-group bbox 1: [1, 2, 100, 100]

POINT (1, 100)
POINT (2. NaN)


-- Row group 2
row-group bbox 2: [3, 3, 300, 300]

POINT (3, 300)
POINT (NaN, NaN)


-- Row group 3
row-group bbox 3: no bbox

POINT (5, NaN)
POINT (6, NaN)


-- Row group 4
row-group bbox 4: [7, 8, 700, 800]

POINT (7, 700)
POINT (8, 800)


-- Row group 5
row-group bbox 5: no bbox

POINT (NaN, NaN)
POINT (NaN, NaN)

-- Row group 6
row-group bbox 5: [9, 9, 900, 900]

LINESTRING EMPTY
POINT (9, 900)

```

### Do these changes have PoC implementations?

Yes, https://github.com/apache/parquet-java/pull/2971 and https://github.com/apache/arrow/pull/45459

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
