### PR TITLE
Fix typo in VariantEncoding

### DIFF
--- a/VariantEncoding.md
+++ b/VariantEncoding.md
@@ -22,7 +22,7 @@
 > [!IMPORTANT]
 > **This specification is still under active development, and has not been formally adopted.**
 
-A Variant represents a type that contain one of:
+A Variant represents a type that contains one of:
 - Primitive: A type and corresponding value (e.g. INT, STRING)
 - Array: An ordered list of Variant values
 - Object: An unordered collection of string/Variant pairs (i.e. key/value pairs). An object may not contain duplicate keys.


### PR DESCRIPTION
Fix verb tense to match `type`


### Rationale for this change

I noticed a small typo in the opening lines of the spec while working on the Rust implementation

### What changes are included in this PR?

Fix a typo


### Do these changes have PoC implementations?
No, there is no implied or explicit change required