### PR TITLE
MINOR: fix a typo in Variant Binary Encoding

### DIFF
--- a/VariantEncoding.md
+++ b/VariantEncoding.md
@@ -455,7 +455,7 @@ As a result, offsets will not necessarily be listed in ascending order.
 The field values are not required to be in the same order as the field IDs, to enable flexibility when constructing Variant values.
 
 An implementation may rely on this field ID order in searching for field names.
-E.g. a binary search on field IDs (combined with metadata lookups) may be used to find a field with a given field.
+E.g. a binary search on field IDs (combined with metadata lookups) may be used to find a field with a given name.
 
 Field names are case-sensitive.
 Field names are required to be unique for each object.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

"to find a field with a given field" did not make sense in the context.

From what I understand, since the fields are listed in lexicographic order of the names, we are able to do a binary search using a given *name*, not a field ID.


### What changes are included in this PR?

Just a typo fix for the variant spec. No code changes.


### Do these changes have PoC implementations?

No


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
