### PR TITLE
GH-502: Define ordering for int96 timestamp

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1076,7 +1076,7 @@ union ColumnOrder {
    *   BOOLEAN - false, true
    *   INT32 - signed comparison
    *   INT64 - signed comparison
-   *   INT96 (only used for legacy timestamps) - undefined
+   *   INT96 (only used for legacy timestamps) - timestamp ordering (first 8 bytes nanoseconds, next 4 bytes julian date)
    *   FLOAT - signed comparison of the represented value (*)
    *   DOUBLE - signed comparison of the represented value (*)
    *   BYTE_ARRAY - unsigned byte-wise comparison

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1076,7 +1076,7 @@ union ColumnOrder {
    *   BOOLEAN - false, true
    *   INT32 - signed comparison
    *   INT64 - signed comparison
-   *   INT96 (only used for legacy timestamps) - timestamp ordering (first 8 bytes nanoseconds, next 4 bytes julian date)
+   *   INT96 (only used for legacy timestamps) - timestamp ordering (LE 8 bytes nanos | LE 4 bytes julian days)
    *   FLOAT - signed comparison of the represented value (*)
    *   DOUBLE - signed comparison of the represented value (*)
    *   BYTE_ARRAY - unsigned byte-wise comparison

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1076,7 +1076,7 @@ union ColumnOrder {
    *   BOOLEAN - false, true
    *   INT32 - signed comparison
    *   INT64 - signed comparison
-   *   INT96 (only used for legacy timestamps) - timestamp ordering (LE 8 bytes nanos | LE 4 bytes julian days)
+   *   INT96 (only used for legacy timestamps) - two level comparison.  Days (last 4 bytes compared as unsigned Little endian int32), nanoseconds (first 8 bytes compared as unsigned little endian int64) 
    *   FLOAT - signed comparison of the represented value (*)
    *   DOUBLE - signed comparison of the represented value (*)
    *   BYTE_ARRAY - unsigned byte-wise comparison


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    [GH-${GITHUB_ISSUE_ID}: ${SUMMARY}
](https://lists.apache.org/thread/6fm50b3pmh6mz659jb5wx5vzmvwccz1n)
or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change


### What changes are included in this PR?


### Do these changes have PoC implementations?
arrow-rs: https://github.com/apache/arrow-rs/issues/7686
parquet-java: https://github.com/apache/parquet-java/pull/3243

Closes #GH-502:
