### PR TITLE
GH-502: Clarify Int96 status and add recommended ordering

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -33,7 +33,7 @@ enum Type {
   BOOLEAN = 0;
   INT32 = 1;
   INT64 = 2;
-  INT96 = 3;  // deprecated, only used by legacy implementations.
+  INT96 = 3;  // deprecated, new Parquet writers should not write data in INT96
   FLOAT = 4;
   DOUBLE = 5;
   BYTE_ARRAY = 6;
@@ -1076,11 +1076,20 @@ union ColumnOrder {
    *   BOOLEAN - false, true
    *   INT32 - signed comparison
    *   INT64 - signed comparison
-   *   INT96 (only used for legacy timestamps) - undefined
+   *   INT96 (only used for legacy timestamps) - undefined(+)
    *   FLOAT - signed comparison of the represented value (*)
    *   DOUBLE - signed comparison of the represented value (*)
    *   BYTE_ARRAY - unsigned byte-wise comparison
    *   FIXED_LEN_BYTE_ARRAY - unsigned byte-wise comparison
+   *
+   * (+) While the INT96 type has been deprecated, at the time of writing it is
+   *    still used in many legacy systems. If a Parquet implementation chooses
+   *    to write statistics for INT96 columns, it is recommended to order them
+   *    according to the legacy rules:
+   *    - compare the last 4 bytes (days) as a little-endian 32-bit signed integer
+   *    - if equal last 4 bytes, compare the first 8 bytes as a little-endian
+   *      64-bit signed integer (nanos)
+   *    See https://github.com/apache/parquet-format/issues/502 for more details
    *
    * (*) Because the sorting order is not specified properly for floating
    *     point values (relations vs. total ordering) the following


### PR DESCRIPTION
### Rationale for this change
- As can be seen on https://github.com/apache/parquet-format/issues/502 and the linked issues, the current state of Int96 is confusing. 
- Given there are proposed changes to various open source parquet writers to make them work better with Int96 despite it being deprecated, we should clarify the spec with respect to Int96 and statistics
- Closes https://github.com/apache/parquet-format/issues/502

### What changes are included in this PR?
1. Add comments clarifying that Int96 should not be written by new parquet writers (@rdblue's suggestion of what deprecated means in practice)
2. Add a recommendation on ordering of Int96 statistics to match what @rahulketch and @alkis are suggesting on https://github.com/apache/parquet-java/issues/3242 and https://github.com/apache/arrow-rs/issues/7686)

### Do these changes have PoC implementations?
No -- in my mind this does not change the meaning or intent of the parquet spec, but instead adds clarification to help other implementers
