### PR TITLE
Minor: Clarify value_metadata in Variant value layout diagram

### DIFF
--- a/VariantEncoding.md
+++ b/VariantEncoding.md
@@ -154,7 +154,7 @@ The entire encoded Variant value includes the `value_metadata` byte, and then 0 
 ```
            7                                  2 1          0
           +------------------------------------+------------+
-value     |            value_header            | basic_type |
+value     |            value_header            | basic_type |  <-- value_metadata
           +------------------------------------+------------+
           |                                                 |
           :                   value_data                    :  <-- 0 or more bytes


### PR DESCRIPTION
### Rationale for this change

When first reading the Variant encoding spec, it can be unclear that each Variant value begins with a single `value_metadata` byte composed of `value_header` and `basic_type`. This can be confusing, especially since “metadata” is also used to refer to the dictionary metadata structure.

The spec already uses the term `value_metadata` in prose, so labeling it clearly in the layout diagram helps reinforce understanding and reduce ambiguity.

### What changes are included in this PR?

- Added a clarifying comment (`<-- value_metadata`) to the value layout diagram to explicitly indicate that the first byte is `value_metadata`.

### Do these changes have PoC implementations?

N/A — documentation-only change, no impact on implementations.