### PR TITLE
GH-508: Finalize Variant and shredding specs

### DIFF
--- a/VariantEncoding.md
+++ b/VariantEncoding.md
@@ -19,9 +19,6 @@
 
 # Variant Binary Encoding
 
-> [!IMPORTANT]
-> **This specification is still under active development, and has not been formally adopted.**
-
 A Variant represents a type that contains one of:
 - Primitive: A type and corresponding value (e.g. INT, STRING)
 - Array: An ordered list of Variant values

--- a/VariantShredding.md
+++ b/VariantShredding.md
@@ -19,9 +19,6 @@
 
 # Variant Shredding
 
-> [!IMPORTANT]
-> **This specification is still under active development, and has not been formally adopted.**
-
 The Variant type is designed to store and process semi-structured data efficiently, even with heterogeneous values.
 Query engines encode each Variant value in a self-describing format, and store it as a group containing `value` and `metadata` binary fields in Parquet.
 Since data is often partially homogeneous, it can be beneficial to extract certain fields into separate Parquet columns to further improve performance.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Per Parquet's requirements, we need at least two reference implementations to finalize the Variant logical type specification and here are the current status:

Java already has the encoding and shredding implementations in place:
https://github.com/apache/parquet-java/pull/3197
https://github.com/apache/parquet-java/pull/3202
https://github.com/apache/parquet-java/issues/3223
https://github.com/apache/parquet-java/issues/3211

Go also includes encoding and shredding support:
https://github.com/apache/arrow-go/pull/344
https://github.com/apache/arrow-go/pull/434

We also have validated cross-language verification between Java and GO languages (https://github.com/apache/arrow-go/pull/455 and https://github.com/apache/parquet-java/pull/3258).

Rust is currently working on the shredding implementation. In addition to these, we already have a full Variant implementation in Apache Iceberg, as well as in some closed-source engines. At this point, I think we have enough implementation coverage to move forward with finalizing the Variant spec.

### What changes are included in this PR?
Remove "under active development" notes from the doc.

### Do these changes have PoC implementations?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #508 
