### PR TITLE
Spec: Clarify variant shredding spec

### DIFF
--- a/VariantShredding.md
+++ b/VariantShredding.md
@@ -125,8 +125,7 @@ If the value is an array, `value` must be null.
 The list `element` must be a required group.
 The `element` group can contain `value` and `typed_value` fields.
 The element's `value` field stores the element as Variant-encoded `binary` when the `typed_value` is not present or cannot represent it.
-The `typed_value` field may be omitted when not shredding elements as a specific type.
-When `typed_value` is omitted, `value` must be `required`.
+The `typed_value` field may be omitted when not shredding elements as a specific type. The `value` field may be omitted when shredding elements as a specific type. However, at least one of the two fields must be present.
 
 For example, a `tags` Variant may be shredded as a list of strings using the following definition:
 ```
@@ -193,6 +192,7 @@ optional group event (VARIANT) {
 ```
 
 The group for each named field must use repetition level `required`.
+Readers may always assume the group is annotated correctly.
 
 A field's `value` and `typed_value` are set to null (missing) to indicate that the field does not exist in the variant.
 To encode a field that is present with a null value, the `value` must contain a Variant null: basic type 0 (primitive) and physical type 0 (null).

--- a/VariantShredding.md
+++ b/VariantShredding.md
@@ -194,7 +194,6 @@ optional group event (VARIANT) {
 ```
 
 The group for each named field must use repetition level `required`.
-Readers may always assume the group has the correct repetition level.
 
 A field's `value` and `typed_value` are set to null (missing) to indicate that the field does not exist in the variant.
 To encode a field that is present with a null value, the `value` must contain a Variant null: basic type 0 (primitive) and physical type 0 (null).

--- a/VariantShredding.md
+++ b/VariantShredding.md
@@ -125,7 +125,9 @@ If the value is an array, `value` must be null.
 The list `element` must be a required group.
 The `element` group can contain `value` and `typed_value` fields.
 The element's `value` field stores the element as Variant-encoded `binary` when the `typed_value` is not present or cannot represent it.
-The `typed_value` field may be omitted when not shredding elements as a specific type. The `value` field may be omitted when shredding elements as a specific type. However, at least one of the two fields must be present.
+The `typed_value` field may be omitted when not shredding elements as a specific type.
+The `value` field may be omitted when shredding elements as a specific type.
+However, at least one of the two fields must be present.
 
 For example, a `tags` Variant may be shredded as a list of strings using the following definition:
 ```
@@ -192,7 +194,7 @@ optional group event (VARIANT) {
 ```
 
 The group for each named field must use repetition level `required`.
-Readers may always assume the group is annotated correctly.
+Readers may always assume the group has the correct repetition level.
 
 A field's `value` and `typed_value` are set to null (missing) to indicate that the field does not exist in the variant.
 To encode a field that is present with a null value, the `value` must contain a Variant null: basic type 0 (primitive) and physical type 0 (null).


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
From the test in https://github.com/apache/arrow-go/pull/455 which validates the cross-language variant implementation, we may need to update a few wording in the spec to make it clear 

### What changes are included in this PR?
- In variant array, either `value` and `typed_value` fields can be omitted but not both in array elements. 

### Do these changes have PoC implementations?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
