### PR TITLE
spec: remove the longitude wraparound of the geometry type bbox

### DIFF
--- a/Geospatial.md
+++ b/Geospatial.md
@@ -41,6 +41,9 @@ may also be used if the WKB representation remains wire-compatible.
 Coordinate Reference System (CRS) is a mapping of how coordinates refer to
 locations on Earth.
 
+For `geometry` type, the CRS does not affect geometric calculations, which 
+are always Cartesian.
+
 The default CRS `OGC:CRS84` means that the geospatial features must be stored
 in the order of longitude/latitude based on the WGS84 datum.
 
@@ -100,7 +103,7 @@ only null or NaN values, that dimension is omitted from the bounding box. If
 either the X or Y dimension is missing, then the bounding box itself is not 
 produced.
 
-For the X values only, xmin may be greater than xmax. In this case, an object
+For `geography` type only, xmin may be greater than xmax. In this case, an object
 in this bounding box may match if it contains an X such that `x >= xmin` OR
 `x <= xmax`. This wraparound occurs only when the corresponding bounding box
 crosses the antimeridian line. In geographic terminology, the concepts of `xmin`,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Sync the recent Iceberg spec change to Parquet: https://github.com/apache/iceberg/pull/14250

Geometry type calculation should always be cartesian. A reader / writer should be able to read / write geometry data without understanding CRS.

### What changes are included in this PR?

1. Remove the longitude wraparound of the geometry type bbox
2. Add clarification in the geometry type.

### Do these changes have PoC implementations?

No
