### PR TITLE
GH-541: Document status of file_path

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -970,7 +970,7 @@ struct ColumnChunk {
     * [1] https://lists.apache.org/thread/ootf2kmyg3p01b1bvplpvp4ftd1bt72d
     *
     * There is no other known usage of this field. Specifically, there are no known 
-    * readers that will read externally stored column data if this field is populated 
+    * reference implementations that will read externally stored column data if this field is populated 
     * within a standard parquet file. Making use of the field for this purpose is  
     * not considered part of the Parquet specification.
     **/


### PR DESCRIPTION
### Rationale for this change

`file_path` does not have any proper implementations and we should clarify its current usage, and that future
usage must go through a formal feature addition process.

### What changes are included in this PR?

Clarification on the `file_path` field status.


### Do these changes have PoC implementations?

No.

Closes #541
