### PR TITLE
GH-533: Adaptive Lossless Floating-Point (ALP) Encoding

### DIFF
--- a/Encodings.md
+++ b/Encodings.md
@@ -369,7 +369,6 @@ Bytes  AA 00 A3 BB 11 B4 CC 22 C5 DD 33 D6
 
 ### Adaptive Lossless floating-Point: (ADAPTIVE_LOSSLESS_FLOATING_POINT = 10)
 
-
 Supported Types: FLOAT, DOUBLE, INT32, INT64
 
 This encoding is adapted from the paper "ALP: Adaptive Lossless floating-Point Compression"

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -628,6 +628,11 @@ enum Encoding {
       Support for INT32, INT64 and FIXED_LEN_BYTE_ARRAY added in 2.11.
    */
   BYTE_STREAM_SPLIT = 9;
+
+  /** Encoding for FLOAT, DOUBLE that first losslessly transforms the values to a
+      integer representation which can be quickly decoded using other techniques.
+   */
+   ADAPTIVE_LOSSLESS_FLOATING_POINT = 10;
 }
 
 /**


### PR DESCRIPTION
This is a proposed implementation of the ALP described in 

"ALP: Adaptive Lossless floating-Point Compression" (SIGMOD 2024, https://dl.acm.org/doi/10.1145/3626717

It is based on (largely a reformatted version of) @prtkgaur 's [ALP Encoding Specification Google Doc](https://docs.google.com/document/d/1xz2cudDpN2Y1ImFcTXh15s-3fPtD_aWt/edit)

See rendered preview here: https://github.com/alamb/parquet-format/blob/alamb/alp/Encodings.md#adaptive-lossless-floating-point-adaptive_lossless_floating_point--10

### Rationale for this change

This encoding has the following properties:
* Targets real-world floating-point (IEEE 754) data. 
* It achieves higher compression ratios (close to ZSTD)
* Much faster to decompress than zstd (and other floating point algorithms)

See Mailing List Discussion: https://lists.apache.org/thread/tjtln1mmjqfoql1ls2dw9xpdk91r1909



<img width="696" height="468" alt="Screenshot 2026-01-14 at 2 45 35 PM" src="https://github.com/user-attachments/assets/756eb156-f0d6-4ef1-90d4-04d71a3b11f0" />

Source [ALP Results Document](https://docs.google.com/document/d/1PlyUSfqCqPVwNt8XA-CfRqsbc0NKRG0Kk1FigEm3JOg/edit?tab=t.0#heading=h.5xf60mx6q7xk)

(Todo summarize the mailing list discussion here)


### What changes are included in this PR?
- Closes https://github.com/apache/parquet-format/issues/533

### Do these changes have PoC implementations?
Yes
- [ ] C/C++: https://github.com/apache/arrow/pull/48345


