### PR TITLE
MINOR: Add summary table of encodings and supported types (in Encodings.md) (#550)

### DIFF
--- a/Encodings.md
+++ b/Encodings.md
@@ -27,14 +27,16 @@ used with any page type.
 
 ### Supported Encodings
 
-| Encoding type                                    | Encoding enum                                             | Supported Types                                  |
-| ------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------ |
-| [Plain](#PLAIN)                                  | PLAIN = 0                                                 | All Physical Types                               |
-| [Dictionary Encoding](#DICTIONARY)               | PLAIN_DICTIONARY = 2 (Deprecated) <br> RLE_DICTIONARY = 8 | All Physical Types                               |
-| [Run Length Encoding / Bit-Packing Hybrid](#RLE) | RLE = 3                                                   | BOOLEAN, Dictionary Indices                                          |
-| [Delta Encoding](#DELTAENC)                      | DELTA_BINARY_PACKED = 5                                   | INT32, INT64                                     |
-| [Delta-length byte array](#DELTALENGTH)          | DELTA_LENGTH_BYTE_ARRAY = 6                               | BYTE_ARRAY                                       |
-| [Delta Strings](#DELTASTRING)                    | DELTA_BYTE_ARRAY = 7                                      | BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY                 |
+For details on current implementation status, see the [Implementation Status](https://parquet.apache.org/docs/file-format/implementationstatus/#encodings) page.
+
+| Encoding type                                    | Encoding enum                                             | Supported Types                                   |
+| ------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------- |
+| [Plain](#PLAIN)                                  | PLAIN = 0                                                 | All Physical Types                                |
+| [Dictionary Encoding](#DICTIONARY)               | PLAIN_DICTIONARY = 2 (Deprecated) <br> RLE_DICTIONARY = 8 | All Physical Types                                |
+| [Run Length Encoding / Bit-Packing Hybrid](#RLE) | RLE = 3                                                   | BOOLEAN, Dictionary Indices                       |
+| [Delta Encoding](#DELTAENC)                      | DELTA_BINARY_PACKED = 5                                   | INT32, INT64                                      |
+| [Delta-length byte array](#DELTALENGTH)          | DELTA_LENGTH_BYTE_ARRAY = 6                               | BYTE_ARRAY                                        |
+| [Delta Strings](#DELTASTRING)                    | DELTA_BYTE_ARRAY = 7                                      | BYTE_ARRAY, FIXED_LEN_BYTE_ARRAY                  |
 | [Byte Stream Split](#BYTESTREAMSPLIT)            | BYTE_STREAM_SPLIT = 9                                     | INT32, INT64, FLOAT, DOUBLE, FIXED_LEN_BYTE_ARRAY |
 
 ### Deprecated Encodings


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
To make it easier for readers to get an overall picture of Parquet encodings.

### What changes are included in this PR?
Adds a summary table to Encodings.md that lists the encoding types (each linked to its description), enums and targets for different Parquet format versions.

See rendered format here: https://github.com/nkaki/parquet-format/blob/master/Encodings.md

### Do these changes have PoC implementations?
No - Documentation change only

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
- Closes #550
