### PR TITLE
Update wording in Geospatial spec

### DIFF
--- a/Geospatial.md
+++ b/Geospatial.md
@@ -44,8 +44,12 @@ locations on Earth.
 The default CRS `OGC:CRS84` means that the geospatial features must be stored
 in the order of longitude/latitude based on the WGS84 datum.
 
-Custom CRS can be specified by a string value. It is recommended to use an
-identifier-based approach like [Spatial reference identifier][srid].
+Non-defaullt CRS values are specified by any string that uniquely identifies coordinate reference system associated with this type.
+To maximize interoperability suggested (but not limited to) formats for CRS are:
+* `authorithy:identifier` - where `authorithy` represents some well known authorities - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`.
+* `inlined_projjson` - Inlining whole CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) format.
+* `srid:identifier` - [SRID - Spatial reference identifier](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), `identifier` is the SRID itself.
+* `projjson:table_property_name` - where `table_property_name` is the name of a table property where the projjson string is stored
 
 For geographic CRS, longitudes are bound by [-180, 180] and latitudes are bound
 by [-90, 90].
@@ -85,19 +89,19 @@ associated with each point.
 The Z values introduce the third dimension coordinate. Usually they are used to
 indicate the height, or elevation.
 
-M values are an opportunity for a geospatial instance to track a value in a 
-fourth dimension. These values can be used as a linear reference value (e.g., 
+M values are an opportunity for a geospatial instance to track a value in a
+fourth dimension. These values can be used as a linear reference value (e.g.,
 highway milepost value), a timestamp, or some other value as defined by the CRS.
 
 Bounding box is defined as the thrift struct below in the representation of
 min/max value pair of coordinates from each axis. Note that X and Y Values are
 always present. Z and M are omitted for 2D geospatial instances.
 
-When calculating a bounding box, null or NaN values in a coordinate 
-dimension are skipped. For example, `POINT (1 NaN)` contributes a value to X 
-but no values to Y, Z, or M dimension of the bounding box. If a dimension has 
-only null or NaN values, that dimension is omitted from the bounding box. If 
-either the X or Y dimension is missing, then the bounding box itself is not 
+When calculating a bounding box, null or NaN values in a coordinate
+dimension are skipped. For example, `POINT (1 NaN)` contributes a value to X
+but no values to Y, Z, or M dimension of the bounding box. If a dimension has
+only null or NaN values, that dimension is omitted from the bounding box. If
+either the X or Y dimension is missing, then the bounding box itself is not
 produced.
 
 For the X values only, xmin may be greater than xmax. In this case, an object
@@ -149,18 +153,6 @@ In addition, the following rules are applied:
 
 [geometry-types]: https://github.com/opengeospatial/geoparquet/blob/v1.1.0/format-specs/geoparquet.md?plain=1#L159
 [wkb-integer-code]: https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary
-
-# CRS Customization
-
-CRS is represented as a string value. Writer and reader implementations are
-responsible for serializing and deserializing the CRS, respectively.
-
-As a convention to maximize the interoperability, custom CRS values can be
-specified by a string of the format `type:identifier`, where `type` is one of
-the following values:
-
-* `srid`: [Spatial reference identifier](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), `identifier` is the SRID itself.
-* `projjson`: [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), `identifier` is the name of a table property or a file property where the projjson string is stored.
 
 # Coordinate axis order
 

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -46,7 +46,7 @@ in the order of longitude/latitude based on the WGS84 datum.
 
 Non-default CRS values are specified by any case insensitive string that uniquely identifies a coordinate reference system associated with this type.
 To maximize interoperability, suggested (but not limited to) formats for CRS are:
-* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`,  `EPSG:3857`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
+* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`, `EPSG:3857`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
 * `srid:identifier` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where identifier is the numeric SRID value. For example: `SRID:0`.
 * `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in a file level key/value metadata key or table property.
 * `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for `OGC:CRS83`:

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -46,9 +46,9 @@ in the order of longitude/latitude based on the WGS84 datum.
 
 Non-default CRS values are specified by any case insensitive string that uniquely identifies a coordinate reference system associated with this type.
 To maximize interoperability, suggested (but not limited to) formats for CRS are:
-* `authorithy:code` - where `authorithy` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions coordinate reference systems provided by some well known authorities.
+* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions coordinate reference systems provided by some well known authorities.
 * `srid:identifier` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where identifier is the numeric SRID value. For example: `SRID:0`.
-* `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in the table property.
+* `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in a file level key/value metadata key or table property.
 * `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for OGC:CRS83:
 ```
 {

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -44,12 +44,51 @@ locations on Earth.
 The default CRS `OGC:CRS84` means that the geospatial features must be stored
 in the order of longitude/latitude based on the WGS84 datum.
 
-Non-defaullt CRS values are specified by any string that uniquely identifies coordinate reference system associated with this type.
-To maximize interoperability suggested (but not limited to) formats for CRS are:
-* `authorithy:identifier` - where `authorithy` represents some well known authorities - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`.
-* `inlined_projjson` - Inlining whole CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) format.
-* `srid:identifier` - [SRID - Spatial reference identifier](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), `identifier` is the SRID itself.
-* `projjson:table_property_name` - where `table_property_name` is the name of a table property where the projjson string is stored
+Non-default CRS values are specified by any case insensitive string that uniquely identifies a coordinate reference system associated with this type.
+To maximize interoperability, suggested (but not limited to) formats for CRS are:
+* `authorithy:code` - where `authorithy` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions coordinate reference systems provided by some well known authorities.
+* `srid:identifier` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where identifier is the numeric SRID value. For example: `SRID:0`.
+* `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in the table property.
+* `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for OGC:CRS83:
+```
+* `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification.
+```
+{
+  "type": "GeographicCRS",
+  "name": "NAD83",
+  "datum": {
+    "type": "GeodeticReferenceFrame",
+    "name": "North American Datum 1983",
+    "ellipsoid": {
+      "name": "GRS 1980",
+      "semi_major_axis": 6378137,
+      "semi_minor_axis": 6356752.314140356,
+      "unit": "metre"
+    }
+  },
+  "coordinate_system": {
+    "subtype": "ellipsoidal",
+    "axis": [
+      {
+        "name": "Geodetic longitude",
+        "abbreviation": "Lon",
+        "direction": "east",
+        "unit": "degree"
+      },
+      {
+        "name": "Geodetic latitude",
+        "abbreviation": "Lat",
+        "direction": "north",
+        "unit": "degree"
+      }
+    ]
+  },
+  "id": {
+    "authority": "EPSG",
+    "code": 4269
+  }
+}
+```
 
 For geographic CRS, longitudes are bound by [-180, 180] and latitudes are bound
 by [-90, 90].

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -44,10 +44,10 @@ locations on Earth.
 The default CRS `OGC:CRS84` means that the geospatial features must be stored
 in the order of longitude/latitude based on the WGS84 datum.
 
-Non-default CRS values are specified by any case insensitive string that uniquely identifies a coordinate reference system associated with this type.
+Non-default CRS values are specified by any string that uniquely identifies a coordinate reference system associated with this type.
 To maximize interoperability, suggested (but not limited to) formats for CRS are:
-* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`, `EPSG:3857`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
-* `srid:identifier` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where identifier is the numeric SRID value. For example: `SRID:0`.
+* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS. Examples are - `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`, `EPSG:3857`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
+* `srid:identifier` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where identifier is the numeric SRID value. For example: `SRID:0`. 
 * `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in a file level key/value metadata key or table property.
 * `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for `OGC:CRS83`:
 ```

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -49,7 +49,7 @@ To maximize interoperability, suggested (but not limited to) formats for CRS are
 * `<projjson>` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for `OGC:CRS83`: `{"$schema": "https://proj.org/schemas/v0.7/projjson.schema.json","type": "GeographicCRS","name": "NAD83 (CRS83)","datum": {"type": "GeodeticReferenceFrame"...`
 * `<authority>:<code>` - where `<authority>` represents some well known authorities, and `code` is the code used by the authority to identify the CRS. Examples are - `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`, `EPSG:3857`, `IGNF:ATI`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
 * `srid:<identifier>` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where <identifier> is the numeric SRID value. For example: `SRID:0`. 
-* `projjson:<table_property_name>` - where `<table_property_name>` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in a file level key/value metadata key or table property.
+* `projjson:<key_name>` - where <key_name> refers to a key within the file key-value metadata, where CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) format is stored.
 
 For geographic CRS, longitudes are bound by [-180, 180] and latitudes are bound
 by [-90, 90].

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -46,7 +46,7 @@ in the order of longitude/latitude based on the WGS84 datum.
 
 Non-default CRS values are specified by any case insensitive string that uniquely identifies a coordinate reference system associated with this type.
 To maximize interoperability, suggested (but not limited to) formats for CRS are:
-* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions coordinate reference systems provided by some well known authorities.
+* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
 * `srid:identifier` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where identifier is the numeric SRID value. For example: `SRID:0`.
 * `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in a file level key/value metadata key or table property.
 * `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for OGC:CRS83:

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -46,55 +46,10 @@ in the order of longitude/latitude based on the WGS84 datum.
 
 Non-default CRS values are specified by any string that uniquely identifies a coordinate reference system associated with this type.
 To maximize interoperability, suggested (but not limited to) formats for CRS are:
-* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS. Examples are - `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`, `EPSG:3857`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
-* `srid:identifier` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where identifier is the numeric SRID value. For example: `SRID:0`. 
-* `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in a file level key/value metadata key or table property.
-* `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for `OGC:CRS83`:
-```
-{
-  "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
-  "type": "GeographicCRS",
-  "name": "NAD83 (CRS83)",
-  "datum": {
-    "type": "GeodeticReferenceFrame",
-    "name": "North American Datum 1983",
-    "ellipsoid": {
-      "name": "GRS 1980",
-      "semi_major_axis": 6378137,
-      "inverse_flattening": 298.257222101
-    }
-  },
-  "coordinate_system": {
-    "subtype": "ellipsoidal",
-    "axis": [
-      {
-        "name": "Geodetic longitude",
-        "abbreviation": "Lon",
-        "direction": "east",
-        "unit": "degree"
-      },
-      {
-        "name": "Geodetic latitude",
-        "abbreviation": "Lat",
-        "direction": "north",
-        "unit": "degree"
-      }
-    ]
-  },
-  "scope": "Not known.",
-  "area": "North America - onshore and offshore: Canada - Alberta; British Columbia; Manitoba; New Brunswick; Newfoundland and Labrador; Northwest Territories; Nova Scotia; Nunavut; Ontario; Prince Edward Island; Quebec; Saskatchewan; Yukon. Puerto Rico. United States (USA) - Alabama; Alaska; Arizona; Arkansas; California; Colorado; Connecticut; Delaware; Florida; Georgia; Hawaii; Idaho; Illinois; Indiana; Iowa; Kansas; Kentucky; Louisiana; Maine; Maryland; Massachusetts; Michigan; Minnesota; Mississippi; Missouri; Montana; Nebraska; Nevada; New Hampshire; New Jersey; New Mexico; New York; North Carolina; North Dakota; Ohio; Oklahoma; Oregon; Pennsylvania; Rhode Island; South Carolina; South Dakota; Tennessee; Texas; Utah; Vermont; Virginia; Washington; West Virginia; Wisconsin; Wyoming. US Virgin Islands. British Virgin Islands.",
-  "bbox": {
-    "south_latitude": 14.92,
-    "west_longitude": 167.65,
-    "north_latitude": 86.45,
-    "east_longitude": -40.73
-  },
-  "id": {
-    "authority": "OGC",
-    "code": "CRS83"
-  }
-}
-```
+* `<projjson>` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for `OGC:CRS83`: `{"$schema": "https://proj.org/schemas/v0.7/projjson.schema.json","type": "GeographicCRS","name": "NAD83 (CRS83)","datum": {"type": "GeodeticReferenceFrame"...`
+* `<authority>:<code>` - where `<authority>` represents some well known authorities, and `code` is the code used by the authority to identify the CRS. Examples are - `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`, `EPSG:3857`, `IGNF:ATI`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
+* `srid:<identifier>` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where <identifier> is the numeric SRID value. For example: `SRID:0`. 
+* `projjson:<table_property_name>` - where `<table_property_name>` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in a file level key/value metadata key or table property.
 
 For geographic CRS, longitudes are bound by [-180, 180] and latitudes are bound
 by [-90, 90].

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -126,19 +126,19 @@ associated with each point.
 The Z values introduce the third dimension coordinate. Usually they are used to
 indicate the height, or elevation.
 
-M values are an opportunity for a geospatial instance to track a value in a
-fourth dimension. These values can be used as a linear reference value (e.g.,
+M values are an opportunity for a geospatial instance to track a value in a 
+fourth dimension. These values can be used as a linear reference value (e.g., 
 highway milepost value), a timestamp, or some other value as defined by the CRS.
 
 Bounding box is defined as the thrift struct below in the representation of
 min/max value pair of coordinates from each axis. Note that X and Y Values are
 always present. Z and M are omitted for 2D geospatial instances.
 
-When calculating a bounding box, null or NaN values in a coordinate
-dimension are skipped. For example, `POINT (1 NaN)` contributes a value to X
-but no values to Y, Z, or M dimension of the bounding box. If a dimension has
-only null or NaN values, that dimension is omitted from the bounding box. If
-either the X or Y dimension is missing, then the bounding box itself is not
+When calculating a bounding box, null or NaN values in a coordinate 
+dimension are skipped. For example, `POINT (1 NaN)` contributes a value to X 
+but no values to Y, Z, or M dimension of the bounding box. If a dimension has 
+only null or NaN values, that dimension is omitted from the bounding box. If 
+either the X or Y dimension is missing, then the bounding box itself is not 
 produced.
 
 For the X values only, xmin may be greater than xmax. In this case, an object

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -51,8 +51,6 @@ To maximize interoperability, suggested (but not limited to) formats for CRS are
 * `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in the table property.
 * `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for OGC:CRS83:
 ```
-* `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification.
-```
 {
   "type": "GeographicCRS",
   "name": "NAD83",

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -49,7 +49,7 @@ To maximize interoperability, suggested (but not limited to) formats for CRS are
 * `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`,  `EPSG:3857`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
 * `srid:identifier` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where identifier is the numeric SRID value. For example: `SRID:0`.
 * `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in a file level key/value metadata key or table property.
-* `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for OGC:CRS83:
+* `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for `OGC:CRS83`:
 ```
 {
   "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -46,7 +46,7 @@ in the order of longitude/latitude based on the WGS84 datum.
 
 Non-default CRS values are specified by any case insensitive string that uniquely identifies a coordinate reference system associated with this type.
 To maximize interoperability, suggested (but not limited to) formats for CRS are:
-* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
+* `authority:code` - where `authority` represents some well known authorities, and `code` is the code used by the authority to identify the CRS  - examples are `OGC:CRS84`, `OGC:CRS83`, `OGC:CRS27`, `EPSG:4326`,  `EPSG:3857`. See [https://spatialreference.org/](https://spatialreference.org/) for definitions of coordinate reference systems provided by some well known authorities.
 * `srid:identifier` -  A reference using a [Spatial reference identifier (SRID)](https://en.wikipedia.org/wiki/Spatial_reference_system#Identifier), where identifier is the numeric SRID value. For example: `SRID:0`.
 * `projjson:table_property_name` - where `table_property_name` is a reference to a CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), stored in a file level key/value metadata key or table property.
 * `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for OGC:CRS83:

--- a/Geospatial.md
+++ b/Geospatial.md
@@ -52,16 +52,16 @@ To maximize interoperability, suggested (but not limited to) formats for CRS are
 * `projjson` - A complete CRS definition embedded directly using the [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) specification. Example for OGC:CRS83:
 ```
 {
+  "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
   "type": "GeographicCRS",
-  "name": "NAD83",
+  "name": "NAD83 (CRS83)",
   "datum": {
     "type": "GeodeticReferenceFrame",
     "name": "North American Datum 1983",
     "ellipsoid": {
       "name": "GRS 1980",
       "semi_major_axis": 6378137,
-      "semi_minor_axis": 6356752.314140356,
-      "unit": "metre"
+      "inverse_flattening": 298.257222101
     }
   },
   "coordinate_system": {
@@ -81,9 +81,17 @@ To maximize interoperability, suggested (but not limited to) formats for CRS are
       }
     ]
   },
+  "scope": "Not known.",
+  "area": "North America - onshore and offshore: Canada - Alberta; British Columbia; Manitoba; New Brunswick; Newfoundland and Labrador; Northwest Territories; Nova Scotia; Nunavut; Ontario; Prince Edward Island; Quebec; Saskatchewan; Yukon. Puerto Rico. United States (USA) - Alabama; Alaska; Arizona; Arkansas; California; Colorado; Connecticut; Delaware; Florida; Georgia; Hawaii; Idaho; Illinois; Indiana; Iowa; Kansas; Kentucky; Louisiana; Maine; Maryland; Massachusetts; Michigan; Minnesota; Mississippi; Missouri; Montana; Nebraska; Nevada; New Hampshire; New Jersey; New Mexico; New York; North Carolina; North Dakota; Ohio; Oklahoma; Oregon; Pennsylvania; Rhode Island; South Carolina; South Dakota; Tennessee; Texas; Utah; Vermont; Virginia; Washington; West Virginia; Wisconsin; Wyoming. US Virgin Islands. British Virgin Islands.",
+  "bbox": {
+    "south_latitude": 14.92,
+    "west_longitude": 167.65,
+    "north_latitude": 86.45,
+    "east_longitude": -40.73
+  },
   "id": {
-    "authority": "EPSG",
-    "code": 4269
+    "authority": "OGC",
+    "code": "CRS83"
   }
 }
 ```


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Current geospatial spec has wording that different parties interpret differently. This PR aims to resolve the ambiguity.

### What changes are included in this PR?

In this PR spec is updated Geospatial types such that wording is more precise in what is allowed and what is suggested.

As per discussion on https://lists.apache.org/thread/r5x0do8f241bpf565rx8s5s3wc9ogp0f it seems that most of the writers already behave in a way thats descirbed in this PR, so spec should be crisp about that.

### Do these changes have PoC implementations?

Yes, writers are already implementing this

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
