### PR TITLE
GH-561: variant schema examples to use (VARIANT(1))

### DIFF
--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -571,7 +571,8 @@ type `binary`, which is also called `BYTE_ARRAY` in the Parquet thrift definitio
 The `VARIANT` annotated group can be used to store either an unshredded Variant
 value, or a shredded Variant value.
 
-* The Variant group must be annotated with the `VARIANT` logical type.
+* The Variant group must be annotated with the `VARIANT` logical type, with the version number
+  "1" included in the declaration.
 * Both fields `value` and `metadata` must be of type `binary` (called `BYTE_ARRAY`
   in the Parquet thrift definition).
 * The `metadata` field is required and must be a valid Variant metadata component,

--- a/LogicalTypes.md
+++ b/LogicalTypes.md
@@ -572,7 +572,7 @@ The `VARIANT` annotated group can be used to store either an unshredded Variant
 value, or a shredded Variant value.
 
 * The Variant group must be annotated with the `VARIANT` logical type, with the version number
-  "1" included in the declaration.
+  included in the declaration.
 * Both fields `value` and `metadata` must be of type `binary` (called `BYTE_ARRAY`
   in the Parquet thrift definition).
 * The `metadata` field is required and must be a valid Variant metadata component,

--- a/VariantEncoding.md
+++ b/VariantEncoding.md
@@ -53,7 +53,7 @@ A Variant value in Parquet is represented by a group with 2 fields, named `value
 This is the expected unshredded representation in Parquet:
 
 ```
-optional group variant_name (VARIANT) {
+optional group variant_name (VARIANT(1)) {
   required binary metadata;
   required binary value;
 }
@@ -61,7 +61,7 @@ optional group variant_name (VARIANT) {
 
 This is an example representation of a shredded Variant in Parquet:
 ```
-optional group shredded_variant_name (VARIANT) {
+optional group shredded_variant_name (VARIANT(1)) {
   required binary metadata;
   optional binary value;
   optional int64 typed_value;

--- a/VariantShredding.md
+++ b/VariantShredding.md
@@ -44,7 +44,7 @@ When `typed_value` is present, readers **must** reconstruct shredded values acco
 
 For example, a Variant field, `measurement` may be shredded as long values by adding `typed_value` with type `int64`:
 ```
-required group measurement (VARIANT) {
+required group measurement (VARIANT(1)) {
   required binary metadata;
   optional binary value;
   optional int64 typed_value;
@@ -128,7 +128,7 @@ However, at least one of the two fields must be present.
 
 For example, a `tags` Variant may be shredded as a list of strings using the following definition:
 ```
-optional group tags (VARIANT) {
+optional group tags (VARIANT(1)) {
   required binary metadata;
   optional binary value;
   optional group typed_value (LIST) {   # must be optional to allow a null list
@@ -174,7 +174,7 @@ As a result, reads when a field is defined in both `value` and a `typed_value` s
 
 For example, a Variant `event` field may shred `event_type` (`string`) and `event_ts` (`timestamp`) columns using the following definition:
 ```
-optional group event (VARIANT) {
+optional group event (VARIANT(1)) {
   required binary metadata;
   optional binary value;                # a variant, expected to be an object
   optional group typed_value {          # shredded fields for the variant object
@@ -229,7 +229,7 @@ The `typed_value` associated with any Variant `value` field can be any shredded 
 For example, the `event` object above may also shred sub-fields as object (`location`) or array (`tags`).
 
 ```
-optional group event (VARIANT) {
+optional group event (VARIANT(1)) {
   required binary metadata;
   optional binary value;
   optional group typed_value {


### PR DESCRIPTION


### What changes are included in this PR?

Fix schema examples and in logical types doc declare that the version number is required.


### Do these changes have PoC implementations?

Well, without the change parquet-java doesn't compile schemas.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->

- Closes #561
