### PR TITLE
GH-563: Make `ColumnMetaData.path_in_schema` optional

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -888,7 +888,7 @@ struct ColumnMetaData {
   /**
    * Path in schema
    *
-   * The writing of this field has been made optional as of version 2.X.0.
+   * The writing of this field has been made optional as of June 2026.
    * The information contained in this field is easily obtainable from
    * the schema, and redundantly storing it here can lead to unnecessary
    * bloat in the footer. Writers are encouraged to make the writing of

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -885,8 +885,17 @@ struct ColumnMetaData {
    * whether we can decode those pages. **/
   2: required list<Encoding> encodings
 
-  /** Path in schema **/
-  3: required list<string> path_in_schema
+  /**
+   * Path in schema
+   *
+   * The writing of this field has been made optional as of version 2.X.0.
+   * The information contained in this field is easily obtainable from
+   * the schema, and redundantly storing it here can lead to unnecessary
+   * bloat in the footer. Writers are encouraged to make the writing of
+   * this field optional, but for maximal compatibility should default to
+   * writing the field until at least Month 202X.
+   */
+  3: optional list<string> path_in_schema
 
   /** Compression codec **/
   4: required CompressionCodec codec

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -893,7 +893,7 @@ struct ColumnMetaData {
    * the schema, and redundantly storing it here can lead to unnecessary
    * bloat in the footer. Writers are encouraged to make the writing of
    * this field optional, but for maximal compatibility should default to
-   * writing the field until at least Month 202X.
+   * writing the field until at least September 2028.
    */
   3: optional list<string> path_in_schema
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Format, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-format/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
- See #563.

### What changes are included in this PR?
Change `path_in_schema` to optional.

### Do these changes have PoC implementations?
Yes. 

- See https://github.com/apache/arrow-rs/pull/9678
- https://github.com/apache/parquet-java/pull/3470
- https://github.com/apache/arrow/pull/49707

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #563
