### PR TITLE
GH-506: Clarify field ordering for partially shredded object union

### DIFF
--- a/VariantShredding.md
+++ b/VariantShredding.md
@@ -303,8 +303,9 @@ def construct_variant(metadata: Metadata, value: Variant, typed_value: Any) -> V
                 assert typed_value.keys().isdisjoint(value.keys()), "object keys must be disjoint"
 
                 # union the shredded fields and non-shredded fields
-                # (the result is a Variant object; field ID ordering rules
-                # from VariantEncoding.md apply)
+                # (field IDs and offsets must be in the order of the
+                # corresponding field names, sorted lexicographically
+                # (unsigned byte ordering for UTF-8))
                 return VariantObject(metadata, object_fields).union(VariantObject(metadata, value))
 
             else:

--- a/VariantShredding.md
+++ b/VariantShredding.md
@@ -303,6 +303,8 @@ def construct_variant(metadata: Metadata, value: Variant, typed_value: Any) -> V
                 assert typed_value.keys().isdisjoint(value.keys()), "object keys must be disjoint"
 
                 # union the shredded fields and non-shredded fields
+                # (the result is a Variant object; field ID ordering rules
+                # from VariantEncoding.md apply)
                 return VariantObject(metadata, object_fields).union(VariantObject(metadata, value))
 
             else:


### PR DESCRIPTION
The `construct_variant` pseudocode in `VariantShredding.md` uses `.union()` without specifying result field ordering. This adds a comment  cross-referencing VariantEncoding.md's requirement that object field IDs must be sorted lexicographically.

I dug into the code and found that parquet-java already enforces this via `Collections.sort(fields)` in `VariantBuilder.endObject()`, verified by  [TestReadVariant#testPartiallyShreddedObjectOutOfOrder](https://github.com/apache/parquet-java/blob/4c8f4d4b875259e2ece5f96c5ee90a03f78805ec/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadVariant.java#L1035).

Closes #506 