### PR TITLE
RFC: Encode parquet-format `minor_version` in thrift metadata

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1369,8 +1369,8 @@ struct FileMetaData {
     * features the file uses. For example, if a file contains features from parquet-format
     * version 2.4, then this field should be set to "2".
     *
-    * Prior to 2026, some readers support features added in version 2.0 and
-    * greater, but will reject files with the version set to 2.0. It was common
+    * Prior to 2026, some readers supported features added in version 2.0 and
+    * greater, but would reject files with the version set to 2. It was common
     * practice for writers to populate "1" for version even if they used version
     * 2.0.
     *
@@ -1380,20 +1380,19 @@ struct FileMetaData {
     */
   1: required i32 version
 
-  /**
-  * Minor Parquet Format Version
-  *
-  * This corresponds to the highest minor version of the parquet-format whose
-  * features the file uses. For example, if a file contains features from
-  * parquet-format version 2.4, then this field should be set to "4".
-  *
-  * Note that Parquet does not follow semantic versioning and new forward
-  * incompatible features, such as new encodings, can be added in a minor
-  * version. See the documentation[1] for more details on the versioning scheme
-  * and the features added in each version.
-  *
-  * [1]: http://parquet.apache.org/docs/file-format/versions
-  **/
+  /** Minor Parquet Format Version
+    *
+    * This corresponds to the highest minor version of the parquet-format whose
+    * features the file uses. For example, if a file contains features from
+    * parquet-format version 2.4, then this field should be set to "4".
+    *
+    * Note that Parquet does not follow semantic versioning and new
+    * forward-incompatible features, such as new encodings, can be added in
+    * minor versions. See the documentation[1] for more details on the versioning
+    * scheme and the features added in each version.
+    *
+    * [1]: http://parquet.apache.org/docs/file-format/versions
+    */
   10: optional i32 minor_version
 
   /** Parquet schema for this file.  This schema contains metadata for all the columns.

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1363,15 +1363,38 @@ union EncryptionAlgorithm {
  * Description for file metadata
  */
 struct FileMetaData {
-  /** Version of this file
+  /** Major Parquet Format Version
     *
-    * As of December 2025, there is no agreed upon consensus of what constitutes
-    * version 2 of the file. For maximum compatibility with readers, writers should
-    * always populate "1" for version. For maximum compatibility with writers,
-    * readers should accept "1" and "2" interchangeably.  All other versions are
-    * reserved for potential future use-cases.
+    * This corresponds to the highest major version of the parquet-format whose
+    * features the file uses. For example, if a file contains features from parquet-format
+    * version 2.4, then this field should be set to "2".
+    *
+    * Prior to 2026, some readers support features added in version 2.0 and
+    * greater, but will reject files with the version set to 2.0. It was common
+    * practice for writers to populate "1" for version even if they used version
+    * 2.0.
+    *
+    * For maximum compatibility with writers, readers should accept "1" and "2"
+    * interchangeably.  All other versions are reserved for potential future
+    * use-cases.
     */
   1: required i32 version
+
+  /**
+  * Minor Parquet Format Version
+  *
+  * This corresponds to the highest minor version of the parquet-format whose
+  * features the file uses. For example, if a file contains features from
+  * parquet-format version 2.4, then this field should be set to "4".
+  *
+  * Note that Parquet does not follow semantic versioning and new forward
+  * incompatible features, such as new encodings, can be added in a minor
+  * version. See the documentation[1] for more details on the versioning scheme
+  * and the features added in each version.
+  *
+  * [1]: http://parquet.apache.org/docs/file-format/versions
+  **/
+  10: optional i32 minor_version
 
   /** Parquet schema for this file.  This schema contains metadata for all the columns.
    * The schema is represented as a tree with a single root.  The nodes of the tree


### PR DESCRIPTION
### Rationale for this change
- Part of  https://github.com/apache/parquet-format/issues/384

**NOTE**: there is an alternate RFC here
- https://github.com/apache/parquet-format/pull/582


As described on the  [mailing list thread](https://lists.apache.org/thread/st8l40z5n4cx5c22rcog50ws4pkzdc3s) about versions, there is currently no way for a parquet reader to know which if the many parquet features it may encounter in a partcular file

The current `version` field in the thirft metadata is insufficient because:
2. There is no agreed upon definition of `version` and many writers use it incorrectly: https://github.com/apache/parquet-format/blob/74001e41f5c5a1856b29be115f9c992cab16a4bf/src/main/thrift/parquet.thrift#L1368-L1373
1.  Even if we agreed to use the `version` field, version "`2`" has several forward incompatible changes (see https://github.com/apache/parquet-site/pull/186) meaning a reader doesn't know what features it may encounter

### What changes are included in this PR?

Add a `minor_version` field to the thrift metadata to encode the minor version of parquet-format. Readers can use this field to determine what features it may encounter.

This field would be ignored by older readers

### Do these changes have PoC implementations?

Not yet