### PR TITLE
RFC: Add `format_major_version` and `format_minor_version` to thrift metadata

### DIFF
--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1363,15 +1363,45 @@ union EncryptionAlgorithm {
  * Description for file metadata
  */
 struct FileMetaData {
-  /** Version of this file
+  /** Version of this file (DEPRECATED)
+    * This field has been historically used in an inconsistent way, with some writers
+    * writing "1" and some writing "2". This field is now deprecated and should not be used.
     *
-    * As of December 2025, there is no agreed upon consensus of what constitutes
-    * version 2 of the file. For maximum compatibility with readers, writers should
-    * always populate "1" for version. For maximum compatibility with writers,
-    * readers should accept "1" and "2" interchangeably.  All other versions are
-    * reserved for potential future use-cases.
+    * Use format_major_version and format_minor_version instead to indicate the
+    * features that must be supported to read this file.
     */
   1: required i32 version
+
+  /** parquet-format Major Version
+   *
+   * Which parquet-format release version defines the forward incompatible
+   * features required to read this file. Forward incompatible feature include
+   * those which the reader must support such as new encodings. Forward
+   * incompatible features do not include features which are purely optional to
+   * read such as new fields in the metadata.
+   *
+   * For example, a file using features introduced in parquet-format 2.8 such as
+   * BYTE_STREAM_SPLIT encoding should set format_major_version to `2` and
+   * format_minor_version to `8`.
+   *
+   * Note: parquet-format does not follow semantic versioning, and
+   * the same format_major_version contain forward incompatible features. For
+   * example, parquet-format 2.4 introduced the ZSTD compression.
+   *
+   * Open questions:
+   * * Guidance for writing with maximum compatibility (set `version` to 2 and then use major/minor version?)
+   * * Should new versions of parquet-format require writers to set this field? 
+   */
+  10: required i32 format_major_version
+
+  /** parquet-format Minor Version
+   *
+   * The minor version of the parquet-format release which defines the forward
+   * incompatible features which must be supported to read this file. See the
+   * documentation for format_major_version for more details.
+   */
+  10: required i32 format_minor_version
+
 
   /** Parquet schema for this file.  This schema contains metadata for all the columns.
    * The schema is represented as a tree with a single root.  The nodes of the tree

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1387,10 +1387,10 @@ struct FileMetaData {
    * Note: parquet-format does not follow semantic versioning, and
    * the same format_major_version contain forward incompatible features. For
    * example, parquet-format 2.4 introduced the ZSTD compression.
+   * See the documentation[1] for more details on the versioning
+   * scheme and the features added in each version.
    *
-   * Open questions:
-   * * Guidance for writing with maximum compatibility (set `version` to 2 and then use major/minor version?)
-   * * Should new versions of parquet-format require writers to set this field? 
+   * [1]: http://parquet.apache.org/docs/file-format/versions
    */
   10: required i32 format_major_version
 

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1364,44 +1364,47 @@ union EncryptionAlgorithm {
  */
 struct FileMetaData {
   /** Version of this file (DEPRECATED)
-    * This field has been historically used in an inconsistent way, with some writers
-    * writing "1" and some writing "2". This field is now deprecated and should not be used.
     *
-    * Use format_major_version and format_minor_version instead to indicate the
-    * features that must be supported to read this file.
+    * This field has historically been used inconsistently, with some writers
+    * writing "1" and some writing "2", so its value is not a reliable indicator
+    * of the features a file uses. It is superseded by format_major_version and
+    * format_minor_version, which should be used instead to indicate the features
+    * that must be supported to read this file.
+    *
+    * This field remains required for backwards compatibility. For maximum
+    * compatibility with existing readers, writers should populate "1".
     */
   1: required i32 version
 
   /** parquet-format Major Version
    *
-   * Which parquet-format release version defines the forward incompatible
-   * features required to read this file. Forward incompatible feature include
-   * those which the reader must support such as new encodings. Forward
-   * incompatible features do not include features which are purely optional to
-   * read such as new fields in the metadata.
+   * Indicates which parquet-format release version defines the
+   * forward-incompatible features required to read this file. Forward-incompatible
+   * features include those the reader must support, such as new encodings. They
+   * do not include features which are purely optional to read, such as new
+   * fields in the metadata.
    *
    * For example, a file using features introduced in parquet-format 2.8 such as
    * BYTE_STREAM_SPLIT encoding should set format_major_version to `2` and
    * format_minor_version to `8`.
    *
-   * Note: parquet-format does not follow semantic versioning, and
-   * the same format_major_version contain forward incompatible features. For
-   * example, parquet-format 2.4 introduced the ZSTD compression.
-   * See the documentation[1] for more details on the versioning
-   * scheme and the features added in each version.
+   * Note: parquet-format does not follow semantic versioning, and releases
+   * sharing the same format_major_version can introduce forward-incompatible
+   * features. For example, parquet-format 2.4 introduced ZSTD compression.
+   * See the documentation[1] for more details on the versioning scheme and the
+   * features added in each version.
    *
    * [1]: http://parquet.apache.org/docs/file-format/versions
    */
-  10: required i32 format_major_version
+  10: optional i32 format_major_version
 
   /** parquet-format Minor Version
    *
-   * The minor version of the parquet-format release which defines the forward
-   * incompatible features which must be supported to read this file. See the
-   * documentation for format_major_version for more details.
+   * The minor version of the parquet-format release which defines the
+   * forward-incompatible features that must be supported to read this file. See
+   * the documentation for format_major_version for more details.
    */
-  10: required i32 format_minor_version
-
+  11: optional i32 format_minor_version
 
   /** Parquet schema for this file.  This schema contains metadata for all the columns.
    * The schema is represented as a tree with a single root.  The nodes of the tree


### PR DESCRIPTION
### Rationale for this change
- Part of  https://github.com/apache/parquet-format/issues/384

**NOTE**: there is an alternate RFC here
- https://github.com/apache/parquet-format/pull/581

As described on the  [mailing list thread](https://lists.apache.org/thread/st8l40z5n4cx5c22rcog50ws4pkzdc3s) about versions, there is currently no way for a parquet reader to know which if the many parquet features it may encounter in a particular file

The current `version` field in the thirft metadata is insufficient because:
2. There is no agreed upon definition of `version` and many writers use it incorrectly: https://github.com/apache/parquet-format/blob/74001e41f5c5a1856b29be115f9c992cab16a4bf/src/main/thrift/parquet.thrift#L1368-L1373
1.  Even if we agreed to use the `version` field, version "`2`" has several forward incompatible changes (see https://github.com/apache/parquet-site/pull/186) meaning a reader doesn't know what features it may encounter

### What changes are included in this PR?

Add net new `format_major_version` and `format_minor_version` fields to the thrift metadata to encode the version of parquet-format. Readers can use this field to determine what features it may encounter.

## Open questions:
 * Guidance for writing with maximum compatibility (set `version` to 2 and then use major/minor version?)
 * Should new versions of parquet-format require writers to set this field? 
 * Would we ever change the `version` field?

These field would be ignored by older readers

### Do these changes have PoC implementations?

Not yet
