### PR TITLE
GH-583: Introduce chronological ordering for INT96 timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Column Index, and Data Page). These statistics are according to a sort order,
 which is defined for each column in the file footer. Parquet supports common
 sort orders for logical and primitive types and also special orders for types
 with potentially ambiguous semantics (e.g., NaN ordering for floating point
-types). The details are documented in the
+types, INT96 timestamps). The details are documented in the
 [Thrift definition](src/main/thrift/parquet.thrift) in the `ColumnOrder` union.
 
 ## Nested Encoding

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1207,7 +1207,7 @@ union ColumnOrder {
    * must be compared as follows:
    * - Compare the last 4 bytes (days) as a little-endian 32-bit signed integer
    * - If equal last 4 bytes, compare the first 8 bytes (nanos) as a
-   *   little-endinan 64-bit signed integer.
+   *   little-endian 64-bit signed integer.
    */
   3: Int96TimestampOrder INT96_TIMESTAMP_ORDER;
 }

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -28,13 +28,6 @@ namespace java org.apache.parquet.format
  * with the encodings to control the on disk storage format.
  * For example INT16 is not included as a type since a good encoding of INT32
  * would handle this.
- *
- * The INT96 type is used only for timestamps and is laid out as follows:
- * - The lower 4 bytes are little-endian signed 32-bit integer containing the Julian day: the
- *   number of days since the Julian calendar epoch, where Julian day 2440588 corresponds to
- *   1 January 1970 (the Unix epoch).
- * - The upper 8 bytes are little-endian signed 64-bit integer containing the number of nanoseconds
- *   elapsed since the second of the day.
  */
 enum Type {
   BOOLEAN = 0;
@@ -1120,7 +1113,7 @@ union ColumnOrder {
    *   BOOLEAN - false, true
    *   INT32 - signed comparison
    *   INT64 - signed comparison
-   *   INT96 (only used for legacy timestamps) - undefined or signed comparison of the represented value(+)
+   *   INT96 (only used for legacy timestamps) - depends on sort order (+)
    *   FLOAT - signed comparison of the represented value (*)
    *   DOUBLE - signed comparison of the represented value (*)
    *   BYTE_ARRAY - unsigned byte-wise comparison
@@ -1129,9 +1122,13 @@ union ColumnOrder {
    * (+) While the INT96 type has been deprecated, at the time of writing it is
    *     still used in many legacy systems. It is optional for writers to emit
    *     statistics for INT96 columns. Writers that emit stats for such columns
-   *     should use the INT96_TIMESTAMP_ORDER for this type. If TYPE_ORDER is
-   *     used for an INT96 column, readers should ignore statistics for that
-   *     column.
+   *     should use the INT96_TIMESTAMP_ORDER for this type and order the values
+   *     according to the legacy rules:
+   *     - compare the last 4 bytes (days) as a little-endian 32-bit signed integer
+   *     - if equal last 4 bytes, compare the first 8 bytes as a little-endian
+   *       64-bit signed integer (nanos)
+   *     If TYPE_ORDER is used for an INT96 column, readers should ignore statistics
+   *     for that column
    *
    * (*) Because TYPE_ORDER is ambiguous for floating point types due to
    *     underspecified handling of NaN and -0/+0, it is recommended that writers

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1120,9 +1120,11 @@ union ColumnOrder {
    *   FIXED_LEN_BYTE_ARRAY - unsigned byte-wise comparison
    *
    * (+) While the INT96 type has been deprecated, at the time of writing it is
-   *     still used in many legacy systems. It is recommended that writers use
-   *     INT96_TIMESTAMP_ORDER for this type. If TYPE_ORDER is used for an INT96
-   *     column, readers should ignore statistics for that column.
+   *     still used in many legacy systems. It is optional for writers to emit
+   *     statistics for INT96 columns. Writers that emit stats for such columns
+   *     should use the INT96_TIMESTAMP_ORDER for this type. If TYPE_ORDER is
+   *     used for an INT96 column, readers should ignore statistics for that
+   *     column.
    *
    * (*) Because TYPE_ORDER is ambiguous for floating point types due to
    *     underspecified handling of NaN and -0/+0, it is recommended that writers

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1127,8 +1127,9 @@ union ColumnOrder {
    *     - compare the last 4 bytes (days) as a little-endian 32-bit signed integer
    *     - if equal last 4 bytes, compare the first 8 bytes as a little-endian
    *       64-bit signed integer (nanos)
-   *     If TYPE_ORDER is used for an INT96 column, readers should ignore statistics
-   *     for that column
+   *     If TYPE_ORDER is used for an INT96 column, readers should ignore all statistics
+   *     (`min`/`max` fields in `Statistics` and `min_values`/`max_values` fields in
+   *     `ColumnIndex`) for that column.
    *
    * (*) Because TYPE_ORDER is ambiguous for floating point types due to
    *     underspecified handling of NaN and -0/+0, it is recommended that writers

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -1061,6 +1061,9 @@ struct TypeDefinedOrder {}
 /** Empty struct to signal IEEE 754 total order for floating point types */
 struct IEEE754TotalOrder {}
 
+/** Empty struct to signal chronological ordering of physical type INT96 */
+struct Int96TimestampOrder {}
+
 /**
  * Union to specify the order used for the min_value and max_value fields for a
  * column. This union takes the role of an enhanced enum that allows rich
@@ -1070,6 +1073,8 @@ struct IEEE754TotalOrder {}
  * * TypeDefinedOrder - the column uses the order defined by its logical or
  *                      physical type (if there is no logical type).
  * * IEEE754TotalOrder - the floating point column uses IEEE 754 total order.
+ *
+ * * Int96TimestampOrder - the INT96 column uses chronological timestamp order.
  *
  * If the reader does not support the value of this union, min and max stats
  * for this column should be ignored.
@@ -1108,20 +1113,16 @@ union ColumnOrder {
    *   BOOLEAN - false, true
    *   INT32 - signed comparison
    *   INT64 - signed comparison
-   *   INT96 (only used for legacy timestamps) - undefined(+)
+   *   INT96 (only used for legacy timestamps) - undefined or signed comparison of the represented value(+)
    *   FLOAT - signed comparison of the represented value (*)
    *   DOUBLE - signed comparison of the represented value (*)
    *   BYTE_ARRAY - unsigned byte-wise comparison
    *   FIXED_LEN_BYTE_ARRAY - unsigned byte-wise comparison
    *
    * (+) While the INT96 type has been deprecated, at the time of writing it is
-   *    still used in many legacy systems. If a Parquet implementation chooses
-   *    to write statistics for INT96 columns, it is recommended to order them
-   *    according to the legacy rules:
-   *    - compare the last 4 bytes (days) as a little-endian 32-bit signed integer
-   *    - if equal last 4 bytes, compare the first 8 bytes as a little-endian
-   *      64-bit signed integer (nanos)
-   *    See https://github.com/apache/parquet-format/issues/502 for more details
+   *     still used in many legacy systems. It is recommended that writers use
+   *     INT96_TIMESTAMP_ORDER for this type. If TYPE_ORDER is used for an INT96
+   *     column, readers should ignore statistics for that column.
    *
    * (*) Because TYPE_ORDER is ambiguous for floating point types due to
    *     underspecified handling of NaN and -0/+0, it is recommended that writers
@@ -1195,6 +1196,18 @@ union ColumnOrder {
    *   or max_values indicates that all non-null values are NaN.
    */
   2: IEEE754TotalOrder IEEE_754_TOTAL_ORDER;
+
+  /*
+   * The INT96 timestamp type is ordered chronologically. Only columns of
+   * physical type INT96 may use this ordering.
+   *
+   * When writing statistics for columns with INT96_TIMESTAMP_ORDER, two values
+   * must be compared as follows:
+   * - Compare the last 4 bytes (days) as a little-endian 32-bit signed integer
+   * - If equal last 4 bytes, compare the first 8 bytes (nanos) as a
+   *   little-endinan 64-bit signed integer.
+   */
+  3: Int96TimestampOrder INT96_TIMESTAMP_ORDER;
 }
 
 struct PageLocation {
@@ -1278,6 +1291,13 @@ struct ColumnIndex {
    * - If the order of this column is IEEE754_TOTAL_ORDER, then min_values[i]
    *   and max_values[i] of that page must be set to the smallest and largest
    *   NaN values as defined by IEEE 754 total order.
+   *
+   * For columns of physical type INT96, the writer must do the following:
+   * - If the order of this column is not INT96_TIMESTAMP_ORDER, then a column
+   *   index must not be written for this column chunk.
+   * - If the order of this column is INT96_TIMESTAMP_ORDER, the min_values[i]
+   *   and max_values[i] of that page must be set to the smallest and largest
+   *   values as defined by the INT96 chronological timestamp ordering.
    */
   2: required list<binary> min_values
   3: required list<binary> max_values

--- a/src/main/thrift/parquet.thrift
+++ b/src/main/thrift/parquet.thrift
@@ -28,6 +28,13 @@ namespace java org.apache.parquet.format
  * with the encodings to control the on disk storage format.
  * For example INT16 is not included as a type since a good encoding of INT32
  * would handle this.
+ *
+ * The INT96 type is used only for timestamps and is laid out as follows:
+ * - The lower 4 bytes are little-endian signed 32-bit integer containing the Julian day: the
+ *   number of days since the Julian calendar epoch, where Julian day 2440588 corresponds to
+ *   1 January 1970 (the Unix epoch).
+ * - The upper 8 bytes are little-endian signed 64-bit integer containing the number of nanoseconds
+ *   elapsed since the second of the day.
  */
 enum Type {
   BOOLEAN = 0;
@@ -1202,12 +1209,6 @@ union ColumnOrder {
   /*
    * The INT96 timestamp type is ordered chronologically. Only columns of
    * physical type INT96 may use this ordering.
-   *
-   * When writing statistics for columns with INT96_TIMESTAMP_ORDER, two values
-   * must be compared as follows:
-   * - Compare the last 4 bytes (days) as a little-endian 32-bit signed integer
-   * - If equal last 4 bytes, compare the first 8 bytes (nanos) as a
-   *   little-endian 64-bit signed integer.
    */
   3: Int96TimestampOrder INT96_TIMESTAMP_ORDER;
 }


### PR DESCRIPTION
### Rationale for this change
When writing INT96 timestamp columns, writers either omit stats altogether or emit stats using the `TYPE_ORDER` ordering. However, some writers were incorrectly emitting stats via bytewise comparisons, which does not result in chronological INT96 ordering. These stats are incorrect and must be ignored by readers. The goal of this change is to introduce a mechanism for readers to correctly determine the validity of an INT96 column's statistics and ignore them if they are potentially incorrect.

### What changes are included in this PR?
This PR specifies a new `INT96_TIMESTAMP_ORDER` sort order specifically used for INT96 timestamp statistics. Additionally, it suggests writers use this ordering when emitting INT96 stats and that readers *ignore* stats for INT96 `TYPE_ORDER`'d columns.

### Do these changes have PoC implementations?
In-progress

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #583
