### PR TITLE
[GH-533] Mark ALP as in Preview

### DIFF
--- a/Encodings.md
+++ b/Encodings.md
@@ -396,6 +396,14 @@ Bytes  AA 00 A3 BB 11 B4 CC 22 C5 DD 33 D6
 <a name="ALP"></a>
 ### Adaptive Lossless floating-Point: (ALP = 10)
 
+**As of 2026-08-01 this encoding is currently in Preview.**
+
+**Note**: Preview means that 
+1. The encoding is finalized (the specification is stable) 
+2. The implementation is on going in the ecosystem (e.g. parquet-java, etc) but may not be complete
+3. The Parquet community recommends only using the encoding when you are sure your reader supports it.
+4. Writers are recommended to provide an opt-in flag to enable this encoding.
+
 Supported Types: FLOAT, DOUBLE
 
 This encoding is adapted from the paper

--- a/Encodings.md
+++ b/Encodings.md
@@ -396,11 +396,11 @@ Bytes  AA 00 A3 BB 11 B4 CC 22 C5 DD 33 D6
 <a name="ALP"></a>
 ### Adaptive Lossless floating-Point: (ALP = 10)
 
-**As of 2026-08-01 this encoding is currently in Preview.**
+**As of 2026-08-01, this encoding is in Preview.**
 
-**Note**: Preview means that 
-1. The encoding is finalized (the specification is stable) 
-2. The implementation is on going in the ecosystem (e.g. parquet-java, etc) but may not be complete
+**Note**: Preview means that:
+1. The encoding is finalized (the specification is stable).
+2. The implementation is ongoing in the ecosystem (e.g., parquet-java, etc.) but may not be complete.
 3. The Parquet community recommends only using the encoding when you are sure your reader supports it.
 4. Writers are recommended to provide an opt-in flag to enable this encoding.
 


### PR DESCRIPTION
- related to https://github.com/apache/parquet-format/issues/533

### Rationale for this change
We recently approved and merged the new ALP encoding into parquet-format
- https://github.com/apache/parquet-format/issues/533

However, as @divjotarora points out on the mailing list
- https://lists.apache.org/thread/sb4hq0fw19mo8ssov8v87z5jc738qnfd

We do not yet have a good way to communicate downstream in the ecosystem how widely supported it is, and when writers could feel safe enabling ALP encoding

Thus I think we should communicate this more clearly 

### What changes are included in this PR?

1. Add an annotation to ALP saying it is in "preview"
2. Define inline what "preview" means 

**Note 1**: There is a [different ongoing discussion](https://lists.apache.org/thread/qlf8lg90gqq41lllyy9mk2f0skqvftqj) to formalize the notion of "preview" and versioning in Parquet. If this is approved / agreed, I think we would move the definition of preview elsewhere

**Note 2**: @divjotarora I think has proposed an alternative of reverting the ALP encoding  from parquet-format until we have finalized the above versioning discussion.

### Do these changes have PoC implementations?

No