### PR TITLE
GH-530: Add modular footer array-page specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ Additionally, files can contain an optional column index to allow readers to
 skip pages more efficiently. See [PageIndex.md](PageIndex.md) for details and
 the reasoning behind adding these to the format.
 
+The file metadata may also be encoded as a *modular footer*: a struct-of-arrays,
+module-addressable footer format that lets readers fetch and decode metadata in
+proportion to the columns a query projects rather than the width of the table.
+See [`ModularFooter.thrift`](src/main/thrift/ModularFooter.thrift) for the proposed metadata
+definitions, layout, and adoption path.
+
 ## Checksumming
 Pages of all kinds can be individually checksummed. This allows disabling of checksums
 at the HDFS file level, to better support single row lookups. Checksums are calculated

--- a/proposals/MODULAR_FOOTER_ARRAY_PAGES.md
+++ b/proposals/MODULAR_FOOTER_ARRAY_PAGES.md
@@ -1,0 +1,464 @@
+<!--
+  - Licensed to the Apache Software Foundation (ASF) under one
+  - or more contributor license agreements.  See the NOTICE file
+  - distributed with this work for additional information
+  - regarding copyright ownership.  The ASF licenses this file
+  - to you under the Apache License, Version 2.0 (the
+  - "License"); you may not use this file except in compliance
+  - with the License.  You may obtain a copy of the License at
+  -
+  -   http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing,
+  - software distributed under the License is distributed on an
+  - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  - KIND, either express or implied.  See the License for the
+  - specific language governing permissions and limitations
+  - under the License.
+  -->
+
+# Modular footer array pages
+
+---
+Author: Jiayi Wang
+Created: 2026-08-28
+Name: Encode modular-footer arrays as independently framed metadata pages
+Issue: https://github.com/apache/parquet-format/issues/530
+Status: DRAFT
+---
+
+## Description
+
+This proposal changes the physical representation of arrays in the modular footer. Each logical
+array is stored as an independently framed **metadata page**:
+
+```text
+[compact-Thrift MetadataPageHeader][raw uncompressed payload]
+```
+
+The normative Thrift definitions are in
+[`ModularFooterArrayPages.thrift`](../src/main/thrift/ModularFooterArrayPages.thrift).
+
+The payload is not a Thrift `binary` field. The header identifies its meaning, value type,
+encoding, logical cardinality, and byte length. A footer directory locates metadata pages by file
+offset. This is the same separation used by Parquet data pages: Thrift describes a page, while the
+encoding named by the header defines its payload.
+
+Metadata pages do not change the modular footer's logical organization. Schema, placement,
+row-group statistics, offset indexes, column indexes, and file metadata remain independent modules
+with their existing read lifecycles. A metadata page contains one struct-of-arrays field within one
+of those modules; it never combines fields from different modules.
+
+The initial format defines two array encodings:
+
+* `BIT_PACKED`, for dense positional arrays.
+* `SPARSE`, for arrays in which relatively few logical positions have values.
+
+Neither encoding applies general-purpose compression.
+
+## Rationale
+
+Compact Thrift is well suited to schemas, small control structures, and compatible evolution, but
+its lists are sequential. Finding element `i` in a `list<i64>` requires parsing elements `0` through
+`i - 1`, because compact integers have variable width. The modular footer needs a projected reader
+to reach column `c` without walking metadata for all preceding columns.
+
+Encoding every array as a Thrift `binary` field solves addressability but obscures the format's
+layering: most fields appear to be Thrift while their actual type and layout live in prose and
+custom decoders. Metadata pages make the boundary explicit. Thrift remains the evolvable control
+plane; encoded array pages are the data plane.
+
+This design also avoids coupling placement and statistics. They are separate modules and separate
+pages. A reader can locate data pages without reading, understanding, or fetching statistics.
+
+## Logical indexing
+
+Unless a field specifies another domain, per-column-chunk arrays use **chunk space**. For leaf
+column `c` and row group `g`, the logical index is:
+
+```text
+i = c * num_row_groups + g
+```
+
+Therefore all row groups of one leaf column are contiguous. Per-column arrays use `i = c`.
+Per-page arrays inside an offset-index or column-index chunk use page ordinal as `i`.
+
+Every page declares `num_values`, the size of its logical domain. A dense page contains a value at
+every position. A sparse page contains a sorted subset of positions from that domain. Absence in a
+sparse page has the same meaning as absence of the corresponding optional field in the traditional
+Thrift footer; it is not a zero or empty value.
+
+## Thrift definitions
+
+The following definitions are added to `ModularFooter.thrift`.
+
+```thrift
+/** The semantic module to which an array page belongs. */
+enum ModularFooterModule {
+  SCHEMA = 0;
+  PLACEMENT = 1;
+  ROW_GROUP_STATS = 2;
+  OFFSET_INDEX = 3;
+  COLUMN_INDEX = 4;
+  FILE_METADATA = 5;
+}
+
+/** Stable identifiers for arrays. Values are never reused for a different meaning. */
+enum MetadataArray {
+  DATA_PAGE_OFFSET = 0;
+  FIRST_DICTIONARY_PAGE = 1;
+  DICTIONARY_PAGE_OFFSET = 2;
+  TOTAL_COMPRESSED_SIZE = 3;
+  TOTAL_UNCOMPRESSED_SIZE = 4;
+  NUM_VALUES = 5;
+  CODEC = 6;
+  PHYSICAL_TYPE = 7;
+  IS_FULLY_DICTIONARY_ENCODED = 8;
+
+  NULL_COUNT = 20;
+  MIN_VALUE = 21;
+  MAX_VALUE = 22;
+  MIN_IS_EXACT = 23;
+  MAX_IS_EXACT = 24;
+  NAN_COUNT = 25;
+
+  PAGE_OFFSET = 40;
+  COMPRESSED_PAGE_SIZE = 41;
+  FIRST_ROW_INDEX = 42;
+  NULL_PAGE = 43;
+  BOUNDARY_ORDER = 44;
+  /** Cumulative absolute offsets of per-column-chunk metadata page groups. */
+  PAGE_GROUP_OFFSET = 45;
+}
+
+/** The values exposed after decoding a page. */
+enum MetadataValueType {
+  BOOLEAN = 0;
+  UINT32 = 1;
+  UINT64 = 2;
+  BYTE_ARRAY = 3;
+}
+
+enum MetadataArrayEncoding {
+  BIT_PACKED = 0;
+  SPARSE = 1;
+}
+
+/** The logical domain in which page positions are interpreted. */
+enum MetadataPageScope {
+  /** File-wide array: chunk space, column space, or another field-defined domain. */
+  FILE = 0;
+  /** Array over the data pages of one (leaf column, row group) column chunk. */
+  COLUMN_CHUNK = 1;
+}
+
+/** Parameters for a dense BIT_PACKED payload. */
+struct BitPackedEncodingHeader {
+  /** Width of each integer, or each BYTE_ARRAY offset, in bits. */
+  1: required i8 bit_width;
+}
+
+/** Parameters for a SPARSE payload. */
+struct SparseEncodingHeader {
+  /** Number of positions that are present. */
+  1: required i32 num_present;
+  /** Width of a logical position in the positions stream. */
+  2: required i8 position_bit_width;
+  /** Width of each integer value, or each BYTE_ARRAY offset, in bits. */
+  3: required i8 value_bit_width;
+}
+
+union MetadataEncodingHeader {
+  1: BitPackedEncodingHeader bit_packed;
+  2: SparseEncodingHeader sparse;
+}
+
+/**
+ * A MetadataPageHeader is compact-Thrift encoded. The raw payload begins immediately after the
+ * struct STOP byte and occupies exactly payload_length bytes. It is not a Thrift binary value.
+ */
+struct MetadataPageHeader {
+  1: required ModularFooterModule module;
+  2: required MetadataArray array;
+  3: required MetadataValueType value_type;
+  4: required MetadataArrayEncoding encoding;
+  /** Number of addressable positions, including absent positions in SPARSE. */
+  5: required i32 num_values;
+  /** Number of raw bytes following this header. */
+  6: required i32 payload_length;
+  7: required MetadataEncodingHeader encoding_header;
+  8: required MetadataPageScope scope;
+  /** Required exactly when scope is COLUMN_CHUNK. */
+  9: optional i32 column_ordinal;
+  /** Required exactly when scope is COLUMN_CHUNK. */
+  10: optional i32 row_group_ordinal;
+}
+
+/** Locates one complete [MetadataPageHeader][payload] record. */
+struct MetadataPageLocation {
+  1: required ModularFooterModule module;
+  2: required MetadataArray array;
+  3: required i64 offset;
+  /** Header plus payload bytes. */
+  4: required i32 length;
+  5: required MetadataPageScope scope;
+  /** Required exactly when scope is COLUMN_CHUNK. */
+  6: optional i32 column_ordinal;
+  /** Required exactly when scope is COLUMN_CHUNK. */
+  7: optional i32 row_group_ordinal;
+}
+```
+
+The page identity `(module, array, scope, column_ordinal, row_group_ordinal)` is repeated in the
+page header and directory deliberately. The directory can select a page without parsing it; the
+page remains self-describing and can validate that the directory did not address the wrong bytes.
+The two ordinals are absent for `FILE` pages. They are both present for `COLUMN_CHUNK` pages and
+identify the column chunk whose page-ordinal domain the payload describes.
+
+## Common payload conventions
+
+All payload integers use little-endian bit order. Within each byte, the least-significant bit is
+consumed first. A packed stream has no padding between values. The final byte is padded with zero
+bits. Readers MUST reject a stream whose unused final bits are nonzero.
+
+The valid width for `UINT32` is 0 through 32 and for `UINT64` is 0 through 64. Width 0 represents an
+all-zero stream and consumes no payload bytes. `BOOLEAN` is equivalent to an unsigned integer of
+width 1; its encoding header MUST specify width 1.
+
+For a stream of `n` integers with width `w`, its byte length is:
+
+```text
+ceil(n * w / 8)
+```
+
+All arithmetic used to validate counts and lengths MUST be checked for overflow before allocating
+memory or reading bytes.
+
+## BIT_PACKED encoding
+
+`BIT_PACKED` represents a dense positional array.
+
+### Integer and boolean values
+
+The payload is exactly one packed stream of `num_values` values using `bit_width` from
+`BitPackedEncodingHeader`:
+
+```text
+[value 0][value 1] ... [value num_values-1]
+```
+
+Value `i` begins at bit offset `i * bit_width`, providing constant-time access without decoding
+preceding values.
+
+Writers MUST choose the minimum width that can represent the largest value. Readers MUST accept a
+larger valid width to permit simple writers, but MUST reject a value outside the declared
+`MetadataValueType` range.
+
+### BYTE_ARRAY values
+
+The payload has two consecutive regions:
+
+```text
+[num_values + 1 packed cumulative offsets][concatenated value bytes]
+```
+
+The offsets use `bit_width`. The first offset MUST be zero, offsets MUST be nondecreasing, and the
+last offset MUST equal the length of the concatenated bytes region. Value `i` is the byte range
+`offset[i] .. offset[i + 1]`.
+
+The offset stream length is derived from `num_values` and `bit_width`; it is not stored separately.
+
+## SPARSE encoding
+
+`SPARSE` represents values at `num_present` positions out of a logical domain of `num_values`.
+The payload starts with a packed positions stream:
+
+```text
+[num_present positions][num_present values]
+```
+
+Positions use `position_bit_width`. They MUST be strictly increasing and each position MUST be less
+than `num_values`. Writers MUST use the minimum width capable of representing
+`num_values - 1`; when `num_values` is zero, `num_present` MUST also be zero and the width MUST be
+zero.
+
+A reader finds logical position `i` by binary-searching the packed positions stream. Fixed-width
+packing allows the reader to inspect any position entry without decoding preceding entries. If the
+position is absent, the logical value is absent. If it is the `k`th present position, its value is
+entry `k` in the values region.
+
+For `UINT32`, `UINT64`, and `BOOLEAN`, the values region is a packed stream of `num_present` values
+using `value_bit_width`.
+
+For `BYTE_ARRAY`, the values region is:
+
+```text
+[num_present + 1 packed cumulative offsets][concatenated value bytes]
+```
+
+The offsets use `value_bit_width` and follow the same validity rules as dense BYTE_ARRAY offsets.
+Consequently, after the positions search, both integer and byte-array values are directly
+addressable without a prefix scan or rank operation.
+
+`SPARSE` MUST NOT be used merely to encode zero values compactly. A missing position means the
+source field was absent; a present value of zero remains present and is encoded in the values
+stream.
+
+## Modules and required pages
+
+The modular footer retains its semantic module boundaries:
+
+* `SCHEMA` is required and is read in full. Its tree-shaped fields MAY remain an ordinary compact-
+  Thrift `SchemaMatrix`; this proposal does not force non-scalar logical types into array pages.
+* `PLACEMENT` is required. Its scalar arrays are metadata pages and normally use `BIT_PACKED`.
+  Placement pages are independently locatable from statistics pages.
+* `ROW_GROUP_STATS` is optional. `NULL_COUNT`, `MIN_VALUE`, `MAX_VALUE`, and `NAN_COUNT` SHOULD use
+  `SPARSE` when their Thrift source fields are not present at every logical position. Exactness
+  flags describe present min/max entries and MAY use dense `BIT_PACKED` when that is smaller.
+* `OFFSET_INDEX` and `COLUMN_INDEX` are optional and remain independently addressable per column
+  chunk. Each array has `COLUMN_CHUNK` scope and uses that chunk's data-page ordinals as its logical
+  positions. Their many per-chunk pages are located through the two-level directory described
+  below; they are not expanded into the root directory.
+* `FILE_METADATA` is read in full and MAY remain an ordinary compact-Thrift structure.
+
+The exact required placement arrays and their semantics remain those specified by the modular
+footer data model. This proposal changes their framing and encoding, not their meaning.
+
+The `MIN_VALUE` and `MAX_VALUE` pages for one statistics domain MUST use identical sparse positions.
+`MIN_IS_EXACT` and `MAX_IS_EXACT` are defined only at those positions. A writer MUST NOT encode one
+bound without the other.
+
+## Directory and footer framing
+
+`ModularFooter` contains the file-level scalars, locations of ordinary Thrift modules, and locations
+of file-scoped metadata pages. The root directory is small and is decoded in full. It MUST NOT
+contain one entry per column chunk.
+
+```thrift
+struct ModularFooter {
+  1: required i32 version;
+  2: required i32 num_row_groups;
+  3: required i32 num_columns;
+  4: required i64 num_rows;
+  5: required list<i64> row_group_num_rows;
+  /** File-scoped pages, including placement, row-group stats, and page-group offset pages. */
+  6: required list<MetadataPageLocation> pages;
+  7: optional list<ModularFooterDirectoryEntry> thrift_modules;
+}
+```
+
+### Two-level directory for page indexes
+
+Expanding every offset-index and column-index array page into `ModularFooter.pages` would make the
+root proportional to `num_columns * num_row_groups`. Instead, each optional page-index module has
+one file-scoped `PAGE_GROUP_OFFSET` page in the root directory. Its dense `UINT64` payload contains
+`num_columns * num_row_groups + 1` cumulative absolute file offsets in chunk-space order.
+
+For chunk index `k`, the half-open byte range
+
+```text
+page_group_offset[k] .. page_group_offset[k + 1]
+```
+
+contains that chunk's `COLUMN_CHUNK`-scoped metadata pages. Equal offsets mean that the chunk has no
+index. Within a nonempty group, pages are concatenated in ascending `MetadataArray` order. A reader
+parses a page header, uses `payload_length` to skip or consume its payload, and continues until the
+group end. Because each group has only the fields of one offset index or column index, this scan is
+bounded by the module schema rather than table width.
+
+The `OFFSET_INDEX/PAGE_GROUP_OFFSET` and `COLUMN_INDEX/PAGE_GROUP_OFFSET` pages are distinct because
+their `module` values differ. Their own locations are ordinary entries in `ModularFooter.pages`.
+
+This document does not change the outer mechanism that locates `ModularFooter` from the end of the
+file. Page and page-group offsets are absolute file offsets, allowing optional modules or large
+page-index groups to be stored outside the always-fetched footer tail.
+
+Each `MetadataPageLocation.length` MUST equal the number of bytes consumed while compact-Thrift
+decoding its header plus `MetadataPageHeader.payload_length`. Page ranges MUST be within the file
+and MUST NOT overlap unless a future version explicitly defines shared pages.
+
+## Reading
+
+To obtain placement for projected leaf column `c`, a reader:
+
+1. Reads the footer index and locates the required placement array pages.
+2. Computes the chunk-space range
+   `[c * num_row_groups, (c + 1) * num_row_groups)`.
+3. Parses each selected page header.
+4. Uses the encoding-specific random-access operation for only that range.
+
+No statistics page is required for this operation. A reader that performs row-group pruning locates
+the relevant statistics pages separately and looks up the same chunk-space positions.
+
+For a sparse page, lookup is `O(log num_present)` due to the positions search. For a bit-packed
+page, lookup is `O(1)`. Neither lookup decodes values belonging to preceding columns.
+
+## Evolution and compatibility
+
+The evolution model is the same as for Parquet data pages:
+
+* Optional additions to `MetadataPageHeader` use normal Thrift field evolution.
+* A new logical array receives a new `MetadataArray` value.
+* A new payload representation receives a new `MetadataArrayEncoding` value and a corresponding
+  `MetadataEncodingHeader` union member.
+* Existing encoding values and payload definitions never change meaning.
+
+An implementation that does not recognize a page type or encoding can skip it using the directory
+length. If the page belongs to an optional optimization module, the implementation proceeds without
+that optimization. If a required schema or placement page is unsupported, the modular footer is
+unusable. During a compatibility transition, the reader falls back to the traditional
+`FileMetaData`; in a modular-footer-only file, it reports an unsupported-format error.
+
+The modular footer itself is a forward-incompatible footer layout when used as the sole footer.
+Metadata-page framing does not add a separate compatibility break beyond that layout change.
+
+## Validation requirements
+
+A conforming reader MUST reject a modular footer when any of the following holds:
+
+* A required schema or placement array page is missing or duplicated.
+* A page's directory identity differs from its header identity.
+* A page's scope and optional ordinals are inconsistent, or an ordinal is outside the file shape.
+* A page-group offset array has the wrong cardinality, is decreasing, or addresses bytes outside
+  the file.
+* Paired min/max pages have different sparse positions or only one of the pair is present.
+* A count, width, or derived length is invalid or overflows.
+* A page extends outside its directory range or the file.
+* Sparse positions are not strictly increasing or are outside the logical domain.
+* BYTE_ARRAY offsets are not nondecreasing or do not terminate at the data length.
+* Packed padding bits are nonzero.
+* Parallel arrays required by the data model have inconsistent logical cardinalities.
+
+Readers SHOULD impose implementation limits on page count, logical cardinality, and payload length
+before allocation. Writers MUST emit pages in canonical `(module, array)` order, although readers
+MUST use the directory and MUST NOT depend on physical order.
+
+## Evaluation
+
+The proposal should be evaluated against the current all-`binary` modular-footer representation and
+the traditional footer using real files, including very wide files with few row groups and files
+with sparse statistics.
+
+The minimum evaluation reports:
+
+* Total footer bytes and always-fetched tail bytes.
+* Directory and Thrift-header overhead.
+* Time to read placement for 1, 5, and all projected columns.
+* Time to read sparse row-group statistics for the same projections.
+* Size and lookup cost of `BIT_PACKED` versus `SPARSE` for every eligible array.
+* Malformed-input and cross-implementation round-trip tests.
+
+Success means that array pages retain projection-scaled access and approximately the same encoded
+size as the current specialized representation, while leaving page identity, encoding selection,
+and future extension in explicit Thrift headers rather than implicit `binary` fields.
+
+## Open questions
+
+1. Should page locations be one flat list or grouped into per-module directories?
+2. Should `MetadataArray` be one global enum or a module-specific field id namespace?
+3. Should writers choose `BIT_PACKED` versus `SPARSE` independently for every page, or should the
+   specification prescribe a deterministic size threshold?
+4. Should optional exactness flags share the sparse position stream of their min/max values, or be
+   independent pages?
+5. What limits on page count and payload size should be normative rather than implementation
+   guidance?

--- a/src/main/thrift/ModularFooter.thrift
+++ b/src/main/thrift/ModularFooter.thrift
@@ -186,25 +186,31 @@ struct SchemaMatrix {
 }
 
 /**
- * Placement module (always present): per-(leaf column, row group) locators, column-major. Every
- * numeric array is `binary` encoded per array_encoding, so a projection random-accesses only its
- * columns' slices instead of decoding the whole module. Dictionary pages use a per-chunk start
- * index (first_dict_page) into a flattened offset array, so a chunk may carry zero, one, or (for a
- * future multi-dictionary feature) several dictionary pages, each located in O(1); the footer does
- * not bake in the current one-dictionary-per-chunk rule.
+ * Placement module (always present): per-(leaf column, row group) chunk locators, column-major
+ * (chunk (c, g) at index c * num_row_groups + g). Per chunk unless a field notes otherwise; every
+ * numeric array is BITPACK-encoded (per array_encoding) for column-selective random access, so a
+ * projection decodes only its columns' slices instead of the whole module.
+ *
+ * Multiple dictionary pages per chunk. Instead of one dictionary_page_offset per chunk,
+ * dictionary_page_offsets is a single flattened array of every dictionary-page offset, and
+ * first_dict_page is a per-chunk cumulative index into it (CSR-style). Chunk k's dictionary pages
+ * are the slice dictionary_page_offsets[first_dict_page[k] : first_dict_page[k+1]], so a chunk may
+ * carry zero, one, or several dictionary pages, each located in O(1). This is why the footer does
+ * not bake in today's one-dictionary-per-chunk rule: a future multi-dictionary feature needs no
+ * format change, only more entries in the flat array.
  */
 struct ColumnChunkMatrix {
   /** First data page byte offset, per (column, row group), column-major. Encoded. */
   1: required binary data_page_offsets;
-  /** Index within dictionary_page_offsets of each chunk's first dictionary page: num_chunks+1
-   *  cumulative entries (first_dict_page[num_chunks] = total). Chunk k's dictionary offsets are
-   *  dictionary_page_offsets[first_dict_page[k] : first_dict_page[k+1]], so its dictionary count is
-   *  the difference and a reader random-accesses it in O(1) with no prefix sum. A chunk with no
-   *  dictionary has an empty slice (first_dict_page[k] == first_dict_page[k+1]); no sentinel used.
+  /** Per-chunk cumulative index into dictionary_page_offsets: num_chunks+1 entries with
+   *  first_dict_page[num_chunks] = total. Chunk k's dictionary pages are the slice
+   *  dictionary_page_offsets[first_dict_page[k] : first_dict_page[k+1]]; the page count is the
+   *  difference (0 = no dictionary), found in O(1) with no prefix sum and no sentinel.
    *  Column-major. Encoded. */
   2: required binary first_dict_page;
-  /** Byte offset of each dictionary page, flattened in column-major chunk order (then in-chunk
-   *  order), sliced by first_dict_page. Encoded. */
+  /** Byte offset of every dictionary page, flattened in column-major chunk order (then page order
+   *  within a chunk) and sliced per chunk by first_dict_page. Holds all of a chunk's dictionary
+   *  pages, so multiple per chunk are supported without a format change. Encoded. */
   3: required binary dictionary_page_offsets;
   /** Compressed size of the column chunk. Encoded. */
   4: required binary total_compressed_sizes;
@@ -214,10 +220,16 @@ struct ColumnChunkMatrix {
   6: required binary num_values;
   /** parquet.CompressionCodec value. Encoded. */
   7: required binary codecs;
-  /** parquet.Type value; one entry per column (uniform across row groups). Encoded. */
+  /** parquet.Type value; one entry per column, uniform across row groups (the noted exception to
+   *  per-chunk). Encoded. */
   8: required binary physical_types;
-  /** Packed bitset: 1 iff every data page in the chunk is dictionary-encoded (the dictionary-
-   *  pushdown fast path). Per chunk, column-major. Replaces ColumnMetaData.encoding_stats. */
+  /** Packed bitset, one bit per chunk: 1 iff every data page in the chunk is dictionary-encoded.
+   *  Replaces ColumnMetaData.encoding_stats. encoding_stats was a variable-length
+   *  list<PageEncodingStats> per chunk (encoding, page type, and counts) that does not fit the
+   *  fixed-width column-major layout and carries far more than readers use. The single fact the
+   *  fast path needs is whether the whole chunk is dictionary-encoded -- so filters and aggregations
+   *  can run directly on dictionary codes without materializing values -- and one bit captures it.
+   *  Per chunk, column-major. */
   9: required binary is_fully_dict_encoded;
 }
 

--- a/src/main/thrift/ModularFooter.thrift
+++ b/src/main/thrift/ModularFooter.thrift
@@ -67,8 +67,8 @@
  * Indexing. The whole-file column-major modules (placement and stats) store each per-chunk array
  * column-major: the value for (leaf column c, row group g) is at index c * num_row_groups + g, so
  * a column's per-row-group values are contiguous. The page index does not use this index; it is
- * split into per-column blobs (OffsetIndexColumn, ColumnIndexColumn), each holding one column's
- * arrays indexed per page (delimited by first_page_index across that column's row groups).
+ * split into one blob per column chunk (OffsetIndexChunk, ColumnIndexChunk), each holding just that
+ * chunk's per-page arrays, located per chunk through a PageIndexDirectory.
  *
  * Every value array is full-length and positional: exactly one entry per chunk (or per page, for
  * the page index) at its index, addressed directly. A parallel presence bitset (has_null_count,
@@ -227,7 +227,7 @@ struct ColumnChunkMatrix {
  * All-NaN chunks: a chunk whose non-null values are all NaN carries no ordering min/max. A reader
  * detects this via nan_count + null_count == num_values (num_values from ColumnChunkMatrix), and
  * such a chunk MAY set has_minmax = 0. The column index cannot use this test (it has no per-page
- * num_values), so it signals the all-NaN case differently (see ColumnIndexColumn).
+ * num_values), so it signals the all-NaN case differently (see ColumnIndexChunk).
  */
 struct RgStatsMatrix {
   /** Packed bitset: 1 iff the null count is known. Per chunk, column-major. */
@@ -256,38 +256,33 @@ struct RgStatsMatrix {
 
 /**
  * Offset-index module (optional, per-page placement): a separate, independent module from the
- * column index. The OFFSET_INDEX directory entry's (offset, length) locates a PageIndexDirectory
- * (the per-column locator), not these blobs; the reader follows that directory's per-column offset
- * to fetch one OffsetIndexColumn per projected leaf column. A column with no offset index has an
+ * column index. The OFFSET_INDEX directory entry locates a PageIndexDirectory (the per-chunk
+ * locator), not these blobs; the reader follows that directory's per-chunk offset to fetch one
+ * OffsetIndexChunk per projected (column, row group) chunk. A chunk with no offset index has an
  * empty slice in the directory.
  *
- * Each OffsetIndexColumn holds one leaf column's pages across its row groups. first_page_index has
- * num_row_groups+1 cumulative entries, so row group g's pages are the flattened slice
- * [first_page_index[g], first_page_index[g+1]). Equivalent to parquet.thrift OffsetIndex,
- * transposed to SoA.
+ * Each OffsetIndexChunk holds one column chunk's pages (one per (leaf column, row group)); the
+ * per-page arrays are parallel and self-delimiting, so their common length is the chunk's page
+ * count and no separate page-count field is stored. Equivalent to parquet.thrift OffsetIndex (SoA).
  */
-struct OffsetIndexColumn {
-  /** Cumulative page index per row group: num_row_groups+1 entries; row group g's pages are the
-   *  flattened slice [first_page_index[g], first_page_index[g+1]) (first_page_index[0] = 0,
-   *  last entry = total pages), giving O(1) access to a row group. Encoded. */
-  1: required binary first_page_index;
+struct OffsetIndexChunk {
   /** Page byte offset. Encoded. */
-  2: required binary offsets;
+  1: required binary offsets;
   /** Compressed page size. Encoded. */
-  3: required binary compressed_page_sizes;
+  2: required binary compressed_page_sizes;
   /** First row index of the page within its row group. Encoded. */
-  4: required binary first_row_indexes;
+  3: required binary first_row_indexes;
 }
 
 /**
  * Column-index module (optional, per-page statistics): a separate, independent module from the
- * offset index. As with the offset index, the COLUMN_INDEX directory entry's (offset, length)
- * locates a PageIndexDirectory (the per-column locator), not these blobs; a column with no column
- * index has an empty slice there, so a chunk may have an offset index but no column index without
- * either module referencing the other. Equivalent to parquet.thrift ColumnIndex, transposed to SoA;
- * this version omits the optional repetition/definition level histograms and
- * unencoded_byte_array_data_bytes. Per-page min/max use the same prefix + inexact scheme as
- * RgStatsMatrix (common prefix stored once, truncated bounds flagged and still valid).
+ * offset index. As with the offset index, the COLUMN_INDEX directory entry locates a
+ * PageIndexDirectory (the per-chunk locator), not these blobs; a chunk with no column index has an
+ * empty slice there, so a chunk may have an offset index but no column index without either module
+ * referencing the other. Equivalent to parquet.thrift ColumnIndex, transposed to SoA; this version
+ * omits the optional repetition/definition level histograms and unencoded_byte_array_data_bytes.
+ * Per-page min/max use the same prefix + inexact scheme as RgStatsMatrix (common prefix stored
+ * once, truncated bounds flagged and still valid).
  *
  * null_pages is the min/max presence gate (there is no separate has_minmax): every non-null page
  * carries min/max, and where null_pages[i] = 1 the page is all-null, so its minmax_prefixes[i],
@@ -299,36 +294,33 @@ struct OffsetIndexColumn {
  * the writer MUST record the actual NaN min/max for such a page (min/max are not dropped), and a
  * reader that sees a NaN min/max treats the page's non-null values as all NaN.
  *
- * Each ColumnIndexColumn holds one leaf column's pages across its row groups; first_page_index
- * delimits each row group's pages exactly as in OffsetIndexColumn.
+ * Each ColumnIndexChunk holds one column chunk's pages; the per-page arrays are parallel and their
+ * common length is the chunk's page count (no separate page-count field).
  */
-struct ColumnIndexColumn {
-  /** Cumulative page index per row group (num_row_groups+1 entries), as in OffsetIndexColumn.
-   *  Encoded. */
-  1: required binary first_page_index;
-  /** parquet.BoundaryOrder value per row group (num_row_groups entries): whether this column's
-   *  pages within each chunk are ordered, enabling binary-search page skipping. Encoded. */
-  2: required binary boundary_orders;
-  /** Packed bitset: 1 iff the page is all-null. Flattened over pages. */
-  3: required binary null_pages;
-  /** Packed bitset: 1 iff the per-page null count is known. Flattened over pages. */
-  4: required binary has_null_count;
-  /** Per-page null count, non-negative; encoded. Meaningful iff has_null_count. Flattened. */
-  5: required binary null_counts;
-  /** Longest common prefix of each page's min and max (empty if none), pages flattened. */
-  6: required VarLenColumn minmax_prefixes;
-  /** Per-page min with minmax_prefixes stripped (suffix), pages flattened. */
-  7: required VarLenColumn min_suffixes;
-  /** Per-page max with minmax_prefixes stripped (suffix), pages flattened. */
-  8: required VarLenColumn max_suffixes;
-  /** Packed bitset: 1 iff the page min is exact; 0 iff a truncated lower bound. Flattened. */
-  9: required binary min_exact;
-  /** Packed bitset: 1 iff the page max is exact; 0 iff a truncated upper bound. Flattened. */
-  10: required binary max_exact;
-  /** Packed bitset: 1 iff the per-page NaN count is known. Flattened. */
-  11: required binary has_nan_count;
-  /** Per-page NaN count, non-negative; encoded. Meaningful iff has_nan_count. Flattened. */
-  12: required binary nan_counts;
+struct ColumnIndexChunk {
+  /** parquet.BoundaryOrder for this chunk: whether the pages are ordered, enabling binary-search
+   *  page skipping. */
+  1: required parquet.BoundaryOrder boundary_order;
+  /** Packed bitset, one bit per page: 1 iff the page is all-null. */
+  2: required binary null_pages;
+  /** Packed bitset, per page: 1 iff the per-page null count is known. */
+  3: required binary has_null_count;
+  /** Per-page null count, non-negative; encoded. Meaningful iff has_null_count. */
+  4: required binary null_counts;
+  /** Longest common prefix of each page's min and max (empty if none), per page. */
+  5: required VarLenColumn minmax_prefixes;
+  /** Per-page min with minmax_prefixes stripped (suffix). */
+  6: required VarLenColumn min_suffixes;
+  /** Per-page max with minmax_prefixes stripped (suffix). */
+  7: required VarLenColumn max_suffixes;
+  /** Packed bitset, per page: 1 iff the min is exact; 0 iff a truncated lower bound. */
+  8: required binary min_exact;
+  /** Packed bitset, per page: 1 iff the max is exact; 0 iff a truncated upper bound. */
+  9: required binary max_exact;
+  /** Packed bitset, per page: 1 iff the per-page NaN count is known. */
+  10: required binary has_nan_count;
+  /** Per-page NaN count, non-negative; encoded. Meaningful iff has_nan_count. */
+  11: required binary nan_counts;
 }
 
 /**
@@ -346,29 +338,31 @@ struct FileMetadataMatrix {
 }
 
 /**
- * Per-column locator at the base of a page-index region (offset index or column index). The
- * module's directory entry addresses this locator, and its (offset, length) spans the whole region
- * (this directory followed by the per-column blobs). A reader fetches it once, then uses
- * column_offsets to fetch only the projected columns' OffsetIndexColumn or ColumnIndexColumn blobs.
+ * Per-chunk locator at the base of a page-index region (offset index or column index). The module's
+ * directory entry addresses this locator, and its (offset, length) spans the whole region (this
+ * directory followed by the per-chunk blobs). A reader fetches it once, then uses chunk_offsets to
+ * fetch only the projected chunks' OffsetIndexChunk or ColumnIndexChunk blobs.
  *
- * column_offsets holds num_columns+1 cumulative byte offsets relative to the region base, so column
- * c's blob is [region_base + column_offsets[c], region_base + column_offsets[c+1]): one integer per
- * column, no separate length, and an empty slice for a column absent from the module.
+ * chunk_offsets holds num_chunks+1 cumulative byte offsets relative to the region base,
+ * column-major (chunk (c, g) at index c * num_row_groups + g), so that chunk's blob is
+ * [region_base + chunk_offsets[k], region_base + chunk_offsets[k+1]): one integer per chunk, no
+ * separate length, and an empty slice for a chunk absent from the module. A whole column's chunks
+ * are contiguous, so a reader can also range-fetch a column in one read.
  */
 struct PageIndexDirectory {
   /** Encoded per array_encoding (see above). */
-  1: required binary column_offsets;
+  1: required binary chunk_offsets;
 }
 
 /**
  * One entry of the footer directory, locating a module's serialized bytes by absolute file offset.
  * For OFFSET_INDEX and COLUMN_INDEX the offset points to the module's PageIndexDirectory (the
- * per-column locator), not the page data.
+ * per-chunk locator), not the page data.
  */
 struct ModularFooterDirectoryEntry {
   1: required ModularFooterModule module;
   /** Absolute byte offset of the module in the file. For OFFSET_INDEX and COLUMN_INDEX it is the
-   *  page-index region base that PageIndexDirectory.column_offsets are relative to. */
+   *  page-index region base that PageIndexDirectory.chunk_offsets are relative to. */
   2: required i64 offset;
   /** Byte length of the module (for the page index, the region: PageIndexDirectory + blobs). */
   3: required i64 length;

--- a/src/main/thrift/ModularFooter.thrift
+++ b/src/main/thrift/ModularFooter.thrift
@@ -124,8 +124,30 @@ enum ModularFooterModule {
  *   BITPACK (0): `u8 bit_width; varint count`, then `count` values packed bit_width bits each,
  *   LSB-first. bit_width is per payload (each array picks its own minimal width). O(1) random
  *   access: value i is the bit_width-bit field at bit offset i * bit_width.
- * BITPACK is the only encoding for now; the tag is retained so a future encoding (e.g. a compact
- * delta variant) can be added without re-encoding data or bumping the footer version.
+ * Design goals for the array encoding, in priority order: (1) RANDOM ACCESS: a projection or a
+ * predicate must reach one column's slice in O(1) without decoding the rest, so any encoding added
+ * here must keep per-element addressability (BITPACK's fixed bit width; a checkpoint directory for a
+ * delta or variable-length scheme; etc.). (2) ALIGN WITH PARQUET: prefer the encoding families
+ * parquet.thrift already defines (RLE/bit-packing, DELTA_BINARY_PACKED, BYTE_STREAM_SPLIT) over
+ * bespoke schemes, so readers and writers reuse existing machinery and the format stays familiar.
+ * (3) MINIMAL SIZE: the footer is fetched cold on every open, so bytes matter, but never at the cost
+ * of goal (1).
+ *
+ * BITPACK is the only encoding today: it is the simplest scheme that meets goals (1) and (2), and
+ * this proposal deliberately keeps that single scheme rather than committing to a more complex one
+ * before there is evidence. Real footers already show where a better encoding could help. On a
+ * fleet parquet-mr footer (29,322 leaf columns, 78 row groups, ~2.29M chunks), min/max was present
+ * on under 1% of chunks, yet the full-length VarLenColumn keeps an offset slot per chunk regardless,
+ * so its min/max offset arrays cost ~10 MB to index ~0.44 MB of actual values; null_count, by
+ * contrast, was dense and packed efficiently. Sparse gated columns like this, and numeric columns
+ * whose offsets are derivable from a fixed width, are where a present-only, delta, or fixed-width
+ * variant would shrink the footer at equal random-access cost.
+ *
+ * Rather than pick a winner now, the tag stays pluggable and we gather evidence: by replaying real
+ * fleet queries we can re-encode the SAME real footers under candidate encodings and measure
+ * cold-read size and decode cost across the actual workload, then propose the best-supported
+ * encoding as a new enum value. Because the encoding is a self-describing tag, adopting it is
+ * additive: no re-encoding of existing data and no footer-version bump.
  */
 enum ColumnArrayEncoding {
   BITPACK = 0;

--- a/src/main/thrift/ModularFooter.thrift
+++ b/src/main/thrift/ModularFooter.thrift
@@ -71,9 +71,12 @@
  * chunk's per-page arrays, located per chunk through a PageIndexDirectory.
  *
  * Every value array is full-length and positional: exactly one entry per chunk (or per page, for
- * the page index) at its index, addressed directly. A parallel presence bitset (has_null_count,
- * has_minmax, and so on) marks which entries are valid; the slot at the aligned index still exists
- * when the bit is 0 (a zero under fixed-width BITPACK, an empty element in VarLenColumn). Values
+ * the page index) at its index, addressed directly. Because a positional array cannot tell a
+ * genuine 0 (or empty bytes) from an unset value, an optional field pairs its value array with a
+ * presence bitset (has_null_count, has_minmax, and so on) recording which entries are actually set;
+ * this restores the optional/absent semantics the array-of-structs footer gets from Thrift field
+ * presence. The slot at the aligned index still exists when the bit is 0 (a zero under fixed-width
+ * BITPACK, an empty element in VarLenColumn). Values
  * are never compacted to present-only, which would force a popcount over the bitset and destroy
  * O(1) random access. Arrays marked "per column" hold num_columns entries indexed by c; arrays
  * marked "per schema element" follow FileMetaData.schema pre-order. Integer arrays are stored as
@@ -150,7 +153,9 @@ struct VarLenColumn {
 // Boolean columns below are packed bitsets, not list<byte>: a `binary` of ceil(count/8) bytes where
 // entry i is bit i (LSB-first within each byte). One bit per entry, O(1) random-accessible, at 1/8
 // the size of a byte-per-entry list. (Thrift has no bit type; the `binary` carries the packed bits,
-// and the entry count comes from the module's chunk or page count.)
+// and the entry count comes from the module's chunk or page count.) A bitset is used two ways: as
+// boolean data (e.g. null_pages, is_fully_dict_encoded), and as a presence flag gating a paired
+// value array (e.g. has_null_count marks which null_counts entries are set).
 
 /**
  * Schema module: parallel arrays, one entry per schema element in the pre-order flattened tree

--- a/src/main/thrift/ModularFooter.thrift
+++ b/src/main/thrift/ModularFooter.thrift
@@ -33,10 +33,10 @@
  * module column-major, so a reader decodes only the columns, and only the modules, a query needs.
  *
  * Module layout. Each module is serialized as an independent Thrift-compact struct. The
- * ModularFooter index carries the footer-level scalars, the two always-present modules inline
- * (schema and placement), and a directory locating each optional module by absolute file offset,
- * so an optional module can be placed anywhere in the file. See ModularFooterDirectoryEntry and
- * PageIndexDirectory for the mechanics.
+ * ModularFooter index carries only the footer-level scalars and a directory locating every module
+ * by absolute file offset, so any module can be placed anywhere in the file. Nothing is inlined:
+ * schema and placement are always present but, like the optional modules, are reached through the
+ * directory. See ModularFooterDirectoryEntry and PageIndexDirectory for the mechanics.
  *
  * This file defines only the metadata, not the file-level framing that wraps it (the magic, footer
  * location, and any checksum, the analog of Parquet's PAR1 + footer length). The framing is
@@ -91,16 +91,16 @@ namespace cpp parquet.modular
 namespace java org.apache.parquet.format.modular
 
 /**
- * Identifies a module. SCHEMA and PLACEMENT are always present and carried inline in ModularFooter
- * (the `schema` and `chunks` fields), so the directory lists only the optional modules: RG_STATS,
- * OFFSET_INDEX, COLUMN_INDEX, and FILE_METADATA. The two inline kinds remain in the enum as the
- * module taxonomy. (Bloom filters are a planned future module, per the extensibility note above,
- * and get an enum value when specified.)
+ * Identifies a module. Every module is located through the directory by absolute file offset;
+ * nothing is carried inline. SCHEMA and PLACEMENT are always present (the directory always has an
+ * entry for each); ROW_GROUP_STATS, OFFSET_INDEX, COLUMN_INDEX, and FILE_METADATA are optional and
+ * present only when the directory lists them. (Bloom filters are a planned future module, per the
+ * extensibility note above, and get an enum value when specified.)
  */
 enum ModularFooterModule {
   SCHEMA = 0;
   PLACEMENT = 1;
-  RG_STATS = 2;
+  ROW_GROUP_STATS = 2;
   OFFSET_INDEX = 3;
   COLUMN_INDEX = 4;
   FILE_METADATA = 5;
@@ -234,7 +234,7 @@ struct ColumnChunkMatrix {
  * such a chunk MAY set has_minmax = 0. The column index cannot use this test (it has no per-page
  * num_values), so it signals the all-NaN case differently (see ColumnIndexChunk).
  */
-struct RgStatsMatrix {
+struct RowGroupStatsMatrix {
   /** Packed bitset: 1 iff the null count is known. Per chunk, column-major. */
   1: required binary has_null_count;
   /** Null count, non-negative; encoded. Meaningful iff has_null_count. */
@@ -286,7 +286,7 @@ struct OffsetIndexChunk {
  * empty slice there, so a chunk may have an offset index but no column index without either module
  * referencing the other. Equivalent to parquet.thrift ColumnIndex, transposed to SoA; this version
  * omits the optional repetition/definition level histograms and unencoded_byte_array_data_bytes.
- * Per-page min/max use the same prefix + inexact scheme as RgStatsMatrix (common prefix stored
+ * Per-page min/max use the same prefix + inexact scheme as RowGroupStatsMatrix (common prefix stored
  * once, truncated bounds flagged and still valid).
  *
  * null_pages is the min/max presence gate (there is no separate has_minmax): every non-null page
@@ -294,7 +294,7 @@ struct OffsetIndexChunk {
  * min_suffixes[i], and max_suffixes[i] are empty and its min_exact[i] and max_exact[i] are
  * meaningless (the per-page null and nan counts remain valid).
  *
- * All-NaN pages: with no per-page num_values, a reader cannot use the RgStatsMatrix test
+ * All-NaN pages: with no per-page num_values, a reader cannot use the RowGroupStatsMatrix test
  * (nan_count + null_count == num_values) to spot a page whose non-null values are all NaN. Instead
  * the writer MUST record the actual NaN min/max for such a page (min/max are not dropped), and a
  * reader that sees a NaN min/max treats the page's non-null values as all NaN.
@@ -374,14 +374,14 @@ struct ModularFooterDirectoryEntry {
 }
 
 /**
- * Top-level footer index (the always-read skeleton): the footer-level scalars plus the two
- * always-present modules, SchemaMatrix and ColumnChunkMatrix (placement), carried directly. The
- * optional modules (RgStatsMatrix, the page index, file metadata) are not fields here; each is
- * serialized independently and located via `directory`, so a reader decodes only the optional
- * modules it needs. Schema and placement are inline (never in `directory`), and every module's
- * column-major arrays stay independently walkable so a projection touches only its columns' slices.
- * version identifies the metadata layout (like FileMetaData.version); which optional modules are
- * present is given by `directory`.
+ * Top-level footer index (the always-read skeleton): the footer-level scalars plus a directory
+ * locating every module. No module is carried inline. SchemaMatrix and ColumnChunkMatrix
+ * (placement) are always present, so `directory` always has an entry for each; the remaining
+ * modules (RowGroupStatsMatrix, the page index, file metadata) are listed only when present. Each
+ * module is serialized independently and reached through `directory`, so a reader decodes only the
+ * modules it needs, and every module's column-major arrays stay independently walkable so a
+ * projection touches only its columns' slices. version identifies the metadata layout (like
+ * FileMetaData.version); which modules are present is given by `directory`.
  */
 struct ModularFooter {
   /** Metadata layout version (analogous to FileMetaData.version). */
@@ -392,8 +392,7 @@ struct ModularFooter {
   5: required list<i64> row_group_num_rows;
   /** Encoding shared by every encoded array in this footer. BITPACK is the only value today. */
   6: required ColumnArrayEncoding array_encoding;
-  7: required SchemaMatrix schema;        // always present
-  8: required ColumnChunkMatrix chunks;   // placement; always present
-  /** Locations of the optional modules (stats, page index, file metadata). */
-  9: optional list<ModularFooterDirectoryEntry> directory;
+  /** Locates every module by absolute file offset. Always includes SCHEMA and PLACEMENT (both
+   *  always present); the other modules appear only when present. Nothing is inlined. */
+  7: required list<ModularFooterDirectoryEntry> directory;
 }

--- a/src/main/thrift/ModularFooter.thrift
+++ b/src/main/thrift/ModularFooter.thrift
@@ -1,0 +1,400 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Modular Footer: a struct-of-arrays (SoA) encoding of Parquet file metadata.
+ *
+ * STATUS: proposal / draft for discussion.
+ *
+ * The standard footer (parquet.thrift FileMetaData) is an array of structs, one ColumnChunk per
+ * (row group, column). Thrift-compact has no random access into it: even a parser that skips the
+ * field values it does not need must still walk every field header in order, so reaching a
+ * projected column means traversing all num_columns * num_row_groups chunks. The cost scales with
+ * table width, not projection. Interleaving each chunk's heterogeneous fields in one struct also
+ * packs and decodes worse than storing each field as its own homogeneous array.
+ *
+ * The modular footer groups the metadata into independently decodable modules and stores each
+ * module column-major, so a reader decodes only the columns, and only the modules, a query needs.
+ *
+ * Module layout. Each module is serialized as an independent Thrift-compact struct. The
+ * ModularFooter index carries the footer-level scalars, the two always-present modules inline
+ * (schema and placement), and a directory locating each optional module by absolute file offset,
+ * so an optional module can be placed anywhere in the file. See ModularFooterDirectoryEntry and
+ * PageIndexDirectory for the mechanics.
+ *
+ * This file defines only the metadata, not the file-level framing that wraps it (the magic, footer
+ * location, and any checksum, the analog of Parquet's PAR1 + footer length). The framing is
+ * specified separately.
+ *
+ * Compatibility. The modular footer is a forward-incompatible layout: an old reader cannot parse
+ * it in place of FileMetaData. Parquet versioning handles this by signalling a breaking footer
+ * layout change at the file level, so an unaware reader rejects the file cleanly rather than
+ * misreading it.
+ *
+ * Adoption. The target end state is the modular footer as the sole footer, which is what delivers
+ * the full footer-size and projection-scaling benefit. During migration it may instead be written
+ * alongside the standard footer so an unaware reader falls back to FileMetaData; that transitional
+ * coexistence is out of scope here.
+ *
+ * Extensibility. Optional modules are per-file presence flags in the directory, not a migration
+ * state. A new module type is added as a directory entry under a version bump, and a reader treats
+ * an absent or unrecognized module uniformly, so the format never sits in a partially migrated
+ * state. Bloom filters are a planned future module added this way (not specified in this draft).
+ *
+ * Encryption. Footer encryption is unchanged in spirit: the footer key encrypts all modules.
+ * Per-column encryption differs from today's whole-ColumnMetaData scheme. Because placement and
+ * statistics are separate modules, and placement is a shared column-major array whose single-column
+ * value cannot be encrypted under a per-column key, only the per-column statistics are encrypted
+ * (under the column key) while placement stays plaintext. A column's location leaks little; its
+ * min/max are the sensitive part. The full modular-encryption design is specified separately.
+ *
+ * Indexing. The whole-file column-major modules (placement and stats) store each per-chunk array
+ * column-major: the value for (leaf column c, row group g) is at index c * num_row_groups + g, so
+ * a column's per-row-group values are contiguous. The page index does not use this index; it is
+ * split into per-column blobs (OffsetIndexColumn, ColumnIndexColumn), each holding one column's
+ * arrays indexed per page (delimited by first_page_index across that column's row groups).
+ *
+ * Every value array is full-length and positional: exactly one entry per chunk (or per page, for
+ * the page index) at its index, addressed directly. A parallel presence bitset (has_null_count,
+ * has_minmax, and so on) marks which entries are valid; the slot at the aligned index still exists
+ * when the bit is 0 (a zero under fixed-width BITPACK, an empty element in VarLenColumn). Values
+ * are never compacted to present-only, which would force a popcount over the bitset and destroy
+ * O(1) random access. Arrays marked "per column" hold num_columns entries indexed by c; arrays
+ * marked "per schema element" follow FileMetaData.schema pre-order. Integer arrays are stored as
+ * `binary` under one encoding chosen for the whole footer (the ColumnArrayEncoding enum below);
+ * variable-length byte columns (stat min/max and their prefixes) use VarLenColumn so they are
+ * random-accessible too.
+ */
+
+include "parquet.thrift"
+
+namespace cpp parquet.modular
+namespace java org.apache.parquet.format.modular
+
+/**
+ * Identifies a module. SCHEMA and PLACEMENT are always present and carried inline in ModularFooter
+ * (the `schema` and `chunks` fields), so the directory lists only the optional modules: RG_STATS,
+ * OFFSET_INDEX, COLUMN_INDEX, and FILE_METADATA. The two inline kinds remain in the enum as the
+ * module taxonomy. (Bloom filters are a planned future module, per the extensibility note above,
+ * and get an enum value when specified.)
+ */
+enum ModularFooterModule {
+  SCHEMA = 0;
+  PLACEMENT = 1;
+  RG_STATS = 2;
+  OFFSET_INDEX = 3;
+  COLUMN_INDEX = 4;
+  FILE_METADATA = 5;
+}
+
+/**
+ * Encoding of the footer's per-chunk and per-column integer arrays. One encoding is chosen for the
+ * whole footer and named once (ModularFooter.array_encoding); every encoded array uses it, there is
+ * no per-array tag, and a reader MUST reject an unknown value. The shared tag fixes the scheme, not
+ * a bit width: under BITPACK each array carries its own bit_width in its payload, sized to that
+ * array's values, so widths differ across arrays and per-column blobs.
+ *
+ * All encoded values are non-negative. An array with an "absent" case (e.g. null_count) is paired
+ * with a presence bitset (e.g. has_null_count), so the value array never needs a negative sentinel
+ * and BITPACK stays a clean unsigned width. Variable-length byte blobs (min/max stat bytes) and
+ * boolean flag bytes are not integer arrays and are stored as-is; the schema arrays are read
+ * wholesale and stay plain Thrift lists.
+ *
+ * Each encoded array is a self-describing `binary` payload (little-endian; varint = unsigned
+ * LEB128):
+ *   BITPACK (0): `u8 bit_width; varint count`, then `count` values packed bit_width bits each,
+ *   LSB-first. bit_width is per payload (each array picks its own minimal width). O(1) random
+ *   access: value i is the bit_width-bit field at bit offset i * bit_width.
+ * BITPACK is the only encoding for now; the tag is retained so a future encoding (e.g. a compact
+ * delta variant) can be added without re-encoding data or bumping the footer version.
+ */
+enum ColumnArrayEncoding {
+  BITPACK = 0;
+}
+
+/**
+ * A variable-length byte column stored for random access. A Thrift list<binary> is sequential
+ * (reaching element i means walking every element before it), which breaks column-selective
+ * decode. Instead `data` concatenates all elements in column-major order and `offsets` is an
+ * encoded array of count+1 cumulative byte positions (offsets[0] = 0, offsets[count] =
+ * length(data)); element i is data[offsets[i] : offsets[i+1]]. Because `offsets` uses
+ * array_encoding, under BITPACK a reader jumps straight to element i's bounds in O(1). Used for the
+ * column-major byte columns (stat min/max values and their common prefixes). The column is
+ * full-length: one element per chunk or page at its column-major index, with an empty element
+ * (offsets[i] == offsets[i+1]) where the gating presence bit is 0. It keeps a slot for every entry
+ * rather than storing only the present ones, so element i is always at index i.
+ */
+struct VarLenColumn {
+  /** Encoded per array_encoding: count+1 cumulative byte offsets into `data`. */
+  1: required binary offsets;
+  /** Concatenated element bytes, in the column's column-major order. */
+  2: required binary data;
+}
+
+// Boolean columns below are packed bitsets, not list<byte>: a `binary` of ceil(count/8) bytes where
+// entry i is bit i (LSB-first within each byte). One bit per entry, O(1) random-accessible, at 1/8
+// the size of a byte-per-entry list. (Thrift has no bit type; the `binary` carries the packed bits,
+// and the entry count comes from the module's chunk or page count.)
+
+/**
+ * Schema module: parallel arrays, one entry per schema element in the pre-order flattened tree
+ * (same order as FileMetaData.schema). Enum-valued columns use i32 with a sentinel for "absent"
+ * because group nodes lack some attributes. The schema needs no random access: every reader fully
+ * decodes the whole tree (it is required to interpret any projected column), so these stay plain
+ * Thrift lists rather than the random-access `binary` encoding the per-chunk modules use, and keep
+ * their negative "absent" sentinels.
+ */
+struct SchemaMatrix {
+  /** Path segment name of the element. */
+  1: required list<string> names;
+  /** parquet.Type value for leaves; -1 for group nodes. */
+  2: required list<i32> physical_types;
+  /** parquet.FieldRepetitionType value; -1 if absent. */
+  3: required list<i32> repetition_types;
+  /** Number of children; -1 for leaves (distinguishes a leaf from a 0-child group). */
+  4: required list<i32> num_children;
+  /** Length for FIXED_LEN_BYTE_ARRAY; -1 otherwise. */
+  5: required list<i32> type_lengths;
+  /** Field id; -2147483648 (min i32) if unset. */
+  6: required list<i32> field_ids;
+  /** Logical type; an empty union means none. Decimals etc. carried here. */
+  7: required list<parquet.LogicalType> logical_types;
+  /** parquet.ColumnOrder, one per element (empty union = unset, group node, or type-defined order).
+   *  Required to interpret min/max stats, e.g. float NaN and signed-zero ordering. */
+  8: required list<parquet.ColumnOrder> column_orders;
+}
+
+/**
+ * Placement module (always present): per-(leaf column, row group) locators, column-major. Every
+ * numeric array is `binary` encoded per array_encoding, so a projection random-accesses only its
+ * columns' slices instead of decoding the whole module. Dictionary pages use a per-chunk start
+ * index (first_dict_page) into a flattened offset array, so a chunk may carry zero, one, or (for a
+ * future multi-dictionary feature) several dictionary pages, each located in O(1); the footer does
+ * not bake in the current one-dictionary-per-chunk rule.
+ */
+struct ColumnChunkMatrix {
+  /** First data page byte offset, per (column, row group), column-major. Encoded. */
+  1: required binary data_page_offsets;
+  /** Index within dictionary_page_offsets of each chunk's first dictionary page: num_chunks+1
+   *  cumulative entries (first_dict_page[num_chunks] = total). Chunk k's dictionary offsets are
+   *  dictionary_page_offsets[first_dict_page[k] : first_dict_page[k+1]], so its dictionary count is
+   *  the difference and a reader random-accesses it in O(1) with no prefix sum. A chunk with no
+   *  dictionary has an empty slice (first_dict_page[k] == first_dict_page[k+1]); no sentinel used.
+   *  Column-major. Encoded. */
+  2: required binary first_dict_page;
+  /** Byte offset of each dictionary page, flattened in column-major chunk order (then in-chunk
+   *  order), sliced by first_dict_page. Encoded. */
+  3: required binary dictionary_page_offsets;
+  /** Compressed size of the column chunk. Encoded. */
+  4: required binary total_compressed_sizes;
+  /** Uncompressed size of the column chunk. Encoded. */
+  5: required binary total_uncompressed_sizes;
+  /** Number of values in the column chunk. Encoded. */
+  6: required binary num_values;
+  /** parquet.CompressionCodec value. Encoded. */
+  7: required binary codecs;
+  /** parquet.Type value; one entry per column (uniform across row groups). Encoded. */
+  8: required binary physical_types;
+  /** Packed bitset: 1 iff every data page in the chunk is dictionary-encoded (the dictionary-
+   *  pushdown fast path). Per chunk, column-major. Replaces ColumnMetaData.encoding_stats. */
+  9: required binary is_fully_dict_encoded;
+}
+
+/**
+ * Statistics module: per-(leaf column, row group) chunk statistics for row-group pruning,
+ * column-major. Mirrors parquet.Statistics min_value/max_value/null_count with two space
+ * optimizations: the longest common prefix of a chunk's min and max is stored once (min/max keep
+ * only the differing suffix), and either bound may be truncated and flagged inexact (an inexact min
+ * stays a valid lower bound, <= true min; an inexact max a valid upper bound, >= true max), so
+ * pruning stays correct while long values do not bloat the footer.
+ *
+ * All-NaN chunks: a chunk whose non-null values are all NaN carries no ordering min/max. A reader
+ * detects this via nan_count + null_count == num_values (num_values from ColumnChunkMatrix), and
+ * such a chunk MAY set has_minmax = 0. The column index cannot use this test (it has no per-page
+ * num_values), so it signals the all-NaN case differently (see ColumnIndexColumn).
+ */
+struct RgStatsMatrix {
+  /** Packed bitset: 1 iff the null count is known. Per chunk, column-major. */
+  1: required binary has_null_count;
+  /** Null count, non-negative; encoded. Meaningful iff has_null_count. */
+  2: required binary null_counts;
+  /** Packed bitset: 1 iff this chunk has min/max (min/max entries below meaningful iff 1). */
+  3: required binary has_minmax;
+  /** Longest common prefix of each chunk's min and max (empty if none), column-major. */
+  4: required VarLenColumn minmax_prefixes;
+  /** Each chunk's min with minmax_prefixes stripped (suffix only), column-major. */
+  5: required VarLenColumn min_suffixes;
+  /** Each chunk's max with minmax_prefixes stripped (suffix only), column-major. */
+  6: required VarLenColumn max_suffixes;
+  /** Packed bitset: 1 iff min is exact; 0 iff a truncated lower bound (<= true min).
+   *  Meaningful iff has_minmax. */
+  7: required binary min_exact;
+  /** Packed bitset: 1 iff max is exact; 0 iff a truncated upper bound (>= true max).
+   *  Meaningful iff has_minmax. */
+  8: required binary max_exact;
+  /** Packed bitset: 1 iff the NaN count is known (mandatory for float types under total order). */
+  9: required binary has_nan_count;
+  /** NaN count, non-negative; encoded. Meaningful iff has_nan_count. FLOAT/DOUBLE/FLOAT16 only. */
+  10: required binary nan_counts;
+}
+
+/**
+ * Offset-index module (optional, per-page placement): a separate, independent module from the
+ * column index. The OFFSET_INDEX directory entry's (offset, length) locates a PageIndexDirectory
+ * (the per-column locator), not these blobs; the reader follows that directory's per-column offset
+ * to fetch one OffsetIndexColumn per projected leaf column. A column with no offset index has an
+ * empty slice in the directory.
+ *
+ * Each OffsetIndexColumn holds one leaf column's pages across its row groups. first_page_index has
+ * num_row_groups+1 cumulative entries, so row group g's pages are the flattened slice
+ * [first_page_index[g], first_page_index[g+1]). Equivalent to parquet.thrift OffsetIndex,
+ * transposed to SoA.
+ */
+struct OffsetIndexColumn {
+  /** Cumulative page index per row group: num_row_groups+1 entries; row group g's pages are the
+   *  flattened slice [first_page_index[g], first_page_index[g+1]) (first_page_index[0] = 0,
+   *  last entry = total pages), giving O(1) access to a row group. Encoded. */
+  1: required binary first_page_index;
+  /** Page byte offset. Encoded. */
+  2: required binary offsets;
+  /** Compressed page size. Encoded. */
+  3: required binary compressed_page_sizes;
+  /** First row index of the page within its row group. Encoded. */
+  4: required binary first_row_indexes;
+}
+
+/**
+ * Column-index module (optional, per-page statistics): a separate, independent module from the
+ * offset index. As with the offset index, the COLUMN_INDEX directory entry's (offset, length)
+ * locates a PageIndexDirectory (the per-column locator), not these blobs; a column with no column
+ * index has an empty slice there, so a chunk may have an offset index but no column index without
+ * either module referencing the other. Equivalent to parquet.thrift ColumnIndex, transposed to SoA;
+ * this version omits the optional repetition/definition level histograms and
+ * unencoded_byte_array_data_bytes. Per-page min/max use the same prefix + inexact scheme as
+ * RgStatsMatrix (common prefix stored once, truncated bounds flagged and still valid).
+ *
+ * null_pages is the min/max presence gate (there is no separate has_minmax): every non-null page
+ * carries min/max, and where null_pages[i] = 1 the page is all-null, so its minmax_prefixes[i],
+ * min_suffixes[i], and max_suffixes[i] are empty and its min_exact[i] and max_exact[i] are
+ * meaningless (the per-page null and nan counts remain valid).
+ *
+ * All-NaN pages: with no per-page num_values, a reader cannot use the RgStatsMatrix test
+ * (nan_count + null_count == num_values) to spot a page whose non-null values are all NaN. Instead
+ * the writer MUST record the actual NaN min/max for such a page (min/max are not dropped), and a
+ * reader that sees a NaN min/max treats the page's non-null values as all NaN.
+ *
+ * Each ColumnIndexColumn holds one leaf column's pages across its row groups; first_page_index
+ * delimits each row group's pages exactly as in OffsetIndexColumn.
+ */
+struct ColumnIndexColumn {
+  /** Cumulative page index per row group (num_row_groups+1 entries), as in OffsetIndexColumn.
+   *  Encoded. */
+  1: required binary first_page_index;
+  /** parquet.BoundaryOrder value per row group (num_row_groups entries): whether this column's
+   *  pages within each chunk are ordered, enabling binary-search page skipping. Encoded. */
+  2: required binary boundary_orders;
+  /** Packed bitset: 1 iff the page is all-null. Flattened over pages. */
+  3: required binary null_pages;
+  /** Packed bitset: 1 iff the per-page null count is known. Flattened over pages. */
+  4: required binary has_null_count;
+  /** Per-page null count, non-negative; encoded. Meaningful iff has_null_count. Flattened. */
+  5: required binary null_counts;
+  /** Longest common prefix of each page's min and max (empty if none), pages flattened. */
+  6: required VarLenColumn minmax_prefixes;
+  /** Per-page min with minmax_prefixes stripped (suffix), pages flattened. */
+  7: required VarLenColumn min_suffixes;
+  /** Per-page max with minmax_prefixes stripped (suffix), pages flattened. */
+  8: required VarLenColumn max_suffixes;
+  /** Packed bitset: 1 iff the page min is exact; 0 iff a truncated lower bound. Flattened. */
+  9: required binary min_exact;
+  /** Packed bitset: 1 iff the page max is exact; 0 iff a truncated upper bound. Flattened. */
+  10: required binary max_exact;
+  /** Packed bitset: 1 iff the per-page NaN count is known. Flattened. */
+  11: required binary has_nan_count;
+  /** Per-page NaN count, non-negative; encoded. Meaningful iff has_nan_count. Flattened. */
+  12: required binary nan_counts;
+}
+
+/**
+ * File-level metadata module (optional): descriptive metadata a reader does not need to navigate
+ * the footer, namely the writer identity and the arbitrary key/value pairs (Arrow, Spark, or Delta
+ * schema, geo metadata, and so on). Read wholesale (small, never projected) and located via the
+ * directory.
+ */
+struct FileMetadataMatrix {
+  /** Writer identity (like FileMetaData.created_by); lets readers gate on known-bad stats. */
+  1: optional string created_by;
+  /** Arbitrary key/value metadata (as FileMetaData.key_value_metadata). Read wholesale, so it stays
+   *  a plain list rather than a column-major SoA structure. */
+  2: optional list<parquet.KeyValue> key_value_metadata;
+}
+
+/**
+ * Per-column locator at the base of a page-index region (offset index or column index). The
+ * module's directory entry addresses this locator, and its (offset, length) spans the whole region
+ * (this directory followed by the per-column blobs). A reader fetches it once, then uses
+ * column_offsets to fetch only the projected columns' OffsetIndexColumn or ColumnIndexColumn blobs.
+ *
+ * column_offsets holds num_columns+1 cumulative byte offsets relative to the region base, so column
+ * c's blob is [region_base + column_offsets[c], region_base + column_offsets[c+1]): one integer per
+ * column, no separate length, and an empty slice for a column absent from the module.
+ */
+struct PageIndexDirectory {
+  /** Encoded per array_encoding (see above). */
+  1: required binary column_offsets;
+}
+
+/**
+ * One entry of the footer directory, locating a module's serialized bytes by absolute file offset.
+ * For OFFSET_INDEX and COLUMN_INDEX the offset points to the module's PageIndexDirectory (the
+ * per-column locator), not the page data.
+ */
+struct ModularFooterDirectoryEntry {
+  1: required ModularFooterModule module;
+  /** Absolute byte offset of the module in the file. For OFFSET_INDEX and COLUMN_INDEX it is the
+   *  page-index region base that PageIndexDirectory.column_offsets are relative to. */
+  2: required i64 offset;
+  /** Byte length of the module (for the page index, the region: PageIndexDirectory + blobs). */
+  3: required i64 length;
+}
+
+/**
+ * Top-level footer index (the always-read skeleton): the footer-level scalars plus the two
+ * always-present modules, SchemaMatrix and ColumnChunkMatrix (placement), carried directly. The
+ * optional modules (RgStatsMatrix, the page index, file metadata) are not fields here; each is
+ * serialized independently and located via `directory`, so a reader decodes only the optional
+ * modules it needs. Schema and placement are inline (never in `directory`), and every module's
+ * column-major arrays stay independently walkable so a projection touches only its columns' slices.
+ * version identifies the metadata layout (like FileMetaData.version); which optional modules are
+ * present is given by `directory`.
+ */
+struct ModularFooter {
+  /** Metadata layout version (analogous to FileMetaData.version). */
+  1: required i32 version;
+  2: required i32 num_row_groups;
+  3: required i32 num_columns;            // leaf columns
+  4: required i64 num_rows;               // file total
+  5: required list<i64> row_group_num_rows;
+  /** Encoding shared by every encoded array in this footer. BITPACK is the only value today. */
+  6: required ColumnArrayEncoding array_encoding;
+  7: required SchemaMatrix schema;        // always present
+  8: required ColumnChunkMatrix chunks;   // placement; always present
+  /** Locations of the optional modules (stats, page index, file metadata). */
+  9: optional list<ModularFooterDirectoryEntry> directory;
+}

--- a/src/main/thrift/ModularFooterArrayPages.thrift
+++ b/src/main/thrift/ModularFooterArrayPages.thrift
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Array-page physical encoding for the modular footer.
+ *
+ * A metadata page is encoded as:
+ *
+ *   [compact-Thrift MetadataPageHeader][raw payload]
+ *
+ * The payload is not a Thrift binary field. It begins immediately after the
+ * MetadataPageHeader STOP byte and has exactly payload_length bytes. Its layout is selected by
+ * MetadataArrayEncoding, in the same way that a Parquet data page header selects the encoding of
+ * the data page body.
+ *
+ * This file defines the page headers and the always-read footer index. The outer file framing that
+ * locates ModularFooterPageIndex from the end of a file is specified separately.
+ */
+
+include "parquet.thrift"
+
+namespace cpp parquet.modular.page
+namespace java org.apache.parquet.format.modular.page
+
+/** Modules preserve independent read lifecycles; pages never combine modules. */
+enum MetadataModule {
+  SCHEMA = 0,
+  PLACEMENT = 1,
+  ROW_GROUP_STATS = 2,
+  OFFSET_INDEX = 3,
+  COLUMN_INDEX = 4,
+  FILE_METADATA = 5
+}
+
+/**
+ * Stable semantic identifiers for metadata arrays. Numeric values MUST NOT be reused for a
+ * different meaning.
+ */
+enum MetadataArray {
+  DATA_PAGE_OFFSET = 0,
+  FIRST_DICTIONARY_PAGE = 1,
+  DICTIONARY_PAGE_OFFSET = 2,
+  TOTAL_COMPRESSED_SIZE = 3,
+  TOTAL_UNCOMPRESSED_SIZE = 4,
+  NUM_VALUES = 5,
+  CODEC = 6,
+  PHYSICAL_TYPE = 7,
+  IS_FULLY_DICTIONARY_ENCODED = 8,
+
+  NULL_COUNT = 20,
+  MIN_VALUE = 21,
+  MAX_VALUE = 22,
+  MIN_IS_EXACT = 23,
+  MAX_IS_EXACT = 24,
+  NAN_COUNT = 25,
+
+  PAGE_OFFSET = 40,
+  COMPRESSED_PAGE_SIZE = 41,
+  FIRST_ROW_INDEX = 42,
+  NULL_PAGE = 43,
+  BOUNDARY_ORDER = 44,
+
+  /** Cumulative absolute offsets of per-column-chunk metadata page groups. */
+  PAGE_GROUP_OFFSET = 45
+}
+
+/** Logical type of each value exposed by a decoded metadata page. */
+enum MetadataValueType {
+  BOOLEAN = 0,
+  UINT32 = 1,
+  UINT64 = 2,
+  BYTE_ARRAY = 3
+}
+
+/** Initial raw payload encodings. Neither applies general-purpose compression. */
+enum MetadataArrayEncoding {
+  BIT_PACKED = 0,
+  SPARSE = 1
+}
+
+/** The logical domain in which page positions are interpreted. */
+enum MetadataPageScope {
+  /** File-wide chunk space, column space, or another array-defined domain. */
+  FILE = 0,
+  /** Data-page ordinals within one (leaf column, row group) column chunk. */
+  COLUMN_CHUNK = 1
+}
+
+/** Parameters for a dense BIT_PACKED payload. */
+struct BitPackedEncodingHeader {
+  /** Width of each integer value, or each BYTE_ARRAY cumulative offset, in bits. */
+  1: required i8 bit_width
+}
+
+/** Parameters for a SPARSE payload. */
+struct SparseEncodingHeader {
+  /** Number of logical positions that have a value. */
+  1: required i32 num_present,
+  /** Width of each entry in the sorted logical-position stream, in bits. */
+  2: required i8 position_bit_width,
+  /** Width of each integer value, or each BYTE_ARRAY cumulative offset, in bits. */
+  3: required i8 value_bit_width
+}
+
+/** Exactly one member MUST be set, matching MetadataPageHeader.encoding. */
+union MetadataEncodingHeader {
+  1: BitPackedEncodingHeader bit_packed,
+  2: SparseEncodingHeader sparse
+}
+
+/**
+ * Compact-Thrift header immediately followed by raw payload bytes.
+ *
+ * FILE pages omit column_ordinal and row_group_ordinal. COLUMN_CHUNK pages MUST carry both. The
+ * latter identify the column chunk whose data-page ordinals form this page's logical domain.
+ */
+struct MetadataPageHeader {
+  1: required MetadataModule module,
+  2: required MetadataArray array,
+  3: required MetadataValueType value_type,
+  4: required MetadataArrayEncoding encoding,
+  /** Addressable positions, including absent positions under SPARSE. */
+  5: required i32 num_values,
+  /** Raw bytes immediately following this struct's STOP byte. */
+  6: required i32 payload_length,
+  7: required MetadataEncodingHeader encoding_header,
+  8: required MetadataPageScope scope,
+  9: optional i32 column_ordinal,
+  10: optional i32 row_group_ordinal
+}
+
+/** Locates one complete [MetadataPageHeader][payload] record. */
+struct MetadataPageLocation {
+  1: required MetadataModule module,
+  2: required MetadataArray array,
+  3: required MetadataPageScope scope,
+  4: optional i32 column_ordinal,
+  5: optional i32 row_group_ordinal,
+  6: required i64 offset,
+  /** Header plus payload bytes. */
+  7: required i32 length
+}
+
+/** Ordinary compact-Thrift structures that are read in full remain separate modules. */
+enum ThriftMetadataModule {
+  SCHEMA = 0,
+  FILE_METADATA = 1
+}
+
+/** Absolute location of one independently serialized ordinary Thrift module. */
+struct ThriftModuleLocation {
+  1: required ThriftMetadataModule module,
+  2: required i64 offset,
+  3: required i64 length
+}
+
+/**
+ * The always-read root of an array-page modular footer.
+ *
+ * pages contains only FILE-scoped pages. In particular, it contains at most one
+ * PAGE_GROUP_OFFSET page for OFFSET_INDEX and one for COLUMN_INDEX. It MUST NOT expand every
+ * column chunk's page-index arrays into this root.
+ *
+ * A PAGE_GROUP_OFFSET payload has num_columns * num_row_groups + 1 dense UINT64 values in chunk
+ * space. Entry k and k+1 delimit the absolute byte range containing the COLUMN_CHUNK-scoped
+ * metadata pages for chunk k. Equal offsets mean that the chunk has no index. Pages within a
+ * nonempty group are concatenated in ascending MetadataArray order.
+ */
+struct ModularFooterPageIndex {
+  1: required i32 version,
+  2: required i32 num_row_groups,
+  3: required i32 num_columns,
+  4: required i64 num_rows,
+  5: required list<i64> row_group_num_rows,
+  6: required list<MetadataPageLocation> pages,
+  7: optional list<ThriftModuleLocation> thrift_modules
+}


### PR DESCRIPTION
### Rationale for this change

The traditional array-of-structs footer requires readers to walk metadata for every column even
when a query projects only a few columns. The modular footer transposes metadata into independent
column-major modules, but storing every encoded array as a Thrift `binary` field obscures the
boundary between the Thrift control structures and the actual array encoding.

This draft explores an explicit metadata-page model analogous to Parquet data pages: a
Compact-Thrift header followed by a raw, uncompressed array payload. It keeps placement,
statistics, and page indexes as independent modules and supports projected random access without
coupling placement to optional statistics.

### What changes are included in this PR?

* Add the base modular-footer data model and its README entry.
* Add a detailed array-page proposal covering framing, indexing, compatibility, validation, and
  evaluation criteria.
* Add normative Thrift definitions for metadata-page headers and directories.
* Define `BIT_PACKED` for dense arrays and `SPARSE` for sparse optional values.
* Define a two-level directory so page-index metadata does not expand the always-read root.
* Keep metadata-page payloads uncompressed and outside Thrift fields.

### Do these changes have PoC implementations?

Not yet. This is a draft specification intended to establish the wire model before updating the
existing modular-footer PoC. The proposal lists the required size, projection, sparse-statistics,
malformed-input, and cross-implementation evaluations.

<!-- Closes #530 -->
