### PR TITLE
MINOR: Use Thrift 0.24.0 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,8 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -qq protobuf-compiler
           sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
-          wget -qO- https://archive.apache.org/dist/thrift/0.23.0/thrift-0.23.0.tar.gz | tar zxf -
-          cd thrift-0.23.0/
+          wget -qO- https://archive.apache.org/dist/thrift/0.24.0/thrift-0.24.0.tar.gz | tar zxf -
+          cd thrift-0.24.0/
           chmod +x ./configure
           ./configure --disable-libs
           sudo make install


### PR DESCRIPTION
Companion fix for #597, built on its exact head (3a4b3b49c55ac6a90236c6a536d1d3c4358c5407).

### Rationale for this change

#597 updates libthrift and the Maven-required compiler version to 0.24.0, but the test workflow still downloads and installs compiler 0.23.0. Maven therefore stops all JDK 8, 11, 17, and 21 lanes with the deterministic version mismatch before compilation.

### What changes are included in this PR?

The workflow now downloads the official Thrift 0.24.0 archive and enters the matching source directory. This follows the same two-line alignment used for the prior Thrift upgrade in #570 and commit c670caf.

### Do these changes have PoC implementations?

The exact source failure was reproduced with compiler 0.23.0. After building the official 0.24.0 compiler:

- JDK 8: clean verify and Javadocs passed
- JDK 11: clean verify and Javadocs passed
- JDK 17: the workflow install step, verify, and Javadocs passed
- JDK 21: clean verify and Javadocs passed
- Maven RAT reported zero unapproved files
- generated Thrift sources compiled successfully
- workflow YAML parsing and git diff --check passed

AI assistance disclosure: JAIPilot/Codex assisted with diagnosis and verification. The complete one-file diff was reviewed before publication.