### PR TITLE
MINOR: Produce nightly snapshot

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -39,8 +39,8 @@ jobs:
         sudo apt-get update -qq
         sudo apt-get install -qq protobuf-compiler
         sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
-        wget -qO- https://archive.apache.org/dist/thrift/0.23.0/thrift-0.23.0.tar.gz | tar zxf -
-        cd thrift-0.23.0/
+        wget -qO- https://archive.apache.org/dist/thrift/0.24.0/thrift-0.24.0.tar.gz | tar zxf -
+        cd thrift-0.24.0/
         chmod +x ./configure
         ./configure --disable-libs
         sudo make install

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -24,6 +24,9 @@ on:
     paths:
       - 'src/main/thrift/parquet.thrift' # Only run when there are changes in the structure
 
+permissions:
+  contents: read
+
 jobs:
   publish-snapshot:
     if: github.repository == 'apache/parquet-format'

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Publish Snapshot
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  publish-snapshot:
+    if: github.repository == 'apache/parquet-format'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    - uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: 17
+
+    - name: Install Thrift
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -qq protobuf-compiler
+        sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
+        wget -qO- https://archive.apache.org/dist/thrift/0.23.0/thrift-0.23.0.tar.gz | tar zxf -
+        cd thrift-0.23.0/
+        chmod +x ./configure
+        ./configure --disable-libs
+        sudo make install
+
+    - name: Publish snapshot
+      env:
+        ASF_USERNAME: ${{ secrets.NEXUS_USER }}
+        ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
+      run: |
+        echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > "$RUNNER_TEMP/settings.xml"
+        mvn --settings "$RUNNER_TEMP/settings.xml" --batch-mode -ntp -DskipTests deploy

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -35,15 +35,7 @@ jobs:
         java-version: 17
 
     - name: Install Thrift
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -qq protobuf-compiler
-        sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
-        wget -qO- https://archive.apache.org/dist/thrift/0.23.0/thrift-0.23.0.tar.gz | tar zxf -
-        cd thrift-0.23.0/
-        chmod +x ./configure
-        ./configure --disable-libs
-        sudo make install
+      run: ./dev/install-thrift.sh
 
     - name: Publish snapshot
       env:

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -21,15 +21,19 @@ on:
   push:
     branches:
     - master
+    paths:
+      - 'src/main/thrift/parquet.thrift' # Only run when there are changes in the structure
 
 jobs:
   publish-snapshot:
     if: github.repository == 'apache/parquet-format'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
-    - uses: actions/setup-java@v5
+    - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: temurin
         java-version: 17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,15 +49,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin
       - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq protobuf-compiler
-          sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
-          wget -qO- https://archive.apache.org/dist/thrift/0.23.0/thrift-0.23.0.tar.gz | tar zxf -
-          cd thrift-0.23.0/
-          chmod +x ./configure
-          ./configure --disable-libs
-          sudo make install
+        run: ./dev/install-thrift.sh
       - name: install
         run: |
           mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true -Djava.version=${{ matrix.java }}

--- a/dev/install-thrift.sh
+++ b/dev/install-thrift.sh
@@ -22,7 +22,7 @@
 
 set -euo pipefail
 
-THRIFT_VERSION="${THRIFT_VERSION:-0.23.0}"
+THRIFT_VERSION="${THRIFT_VERSION:-0.24.0}"
 
 sudo apt-get update -qq
 sudo apt-get install -qq protobuf-compiler

--- a/dev/install-thrift.sh
+++ b/dev/install-thrift.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Installs Apache Thrift (and its build dependencies) from source.
+# Used by the GitHub Actions workflows to generate the Parquet thrift bindings.
+
+set -euo pipefail
+
+THRIFT_VERSION="${THRIFT_VERSION:-0.23.0}"
+
+sudo apt-get update -qq
+sudo apt-get install -qq protobuf-compiler
+sudo apt-get install -qq libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
+
+wget -qO- "https://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz" | tar zxf -
+cd "thrift-${THRIFT_VERSION}/"
+chmod +x ./configure
+./configure --disable-libs
+sudo make install


### PR DESCRIPTION
### Rationale for this change

This adds a workflow to produce a nightly snapshot. This relies a lot on the parent POM: https://github.com/apache/maven-apache-parent/blob/3130c8b10759e291d95aa51adbb745843b60283a/pom.xml#L90-L92


### What changes are included in this PR?


### Do these changes have PoC implementations?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
